### PR TITLE
Make code more portable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(SDL2 REQUIRED)
 
 # project includes
-include_directories(include)
+include_directories(include ${SDL2_INCLUDE_DIR})
 
 # add the executable
 add_executable(cryxtels

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,4 +17,4 @@ include_directories(include ${SDL2_INCLUDE_DIR})
 # add the executable
 add_executable(cryxtels
     source/cryxtels.cpp source/fast3d.cpp source/global.cpp source/input.cpp source/text3d.cpp)
-target_link_libraries(cryxtels ${SDL2_LIBRARY})
+target_link_libraries(cryxtels ${SDL2_LIBRARY} ${SDL2MAIN_LIBRARY})

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Example on Linux:
 mkdir Release
 cd Release
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make
+cmake --build . --config Release
 ```
 
 The output is the executable file `cryxtels`.

--- a/include/conf.h
+++ b/include/conf.h
@@ -19,7 +19,7 @@
 #ifndef CONF_H_INCLUDED
 #define CONF_H_INCLUDED
 
-#include <SDL2/SDL.h>
+#include "SDL.h"
 constexpr int FRAMES_PER_SECOND = 30;
 
 constexpr unsigned int WIDTH = 320;

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -19,7 +19,7 @@
 #ifndef FAST3D_H_INCLUDED
 #define FAST3D_H_INCLUDED
 
-#include <SDL2/SDL.h>
+#include "SDL.h"
 #include <memory>
 
 #ifndef far

--- a/include/global.h
+++ b/include/global.h
@@ -23,6 +23,8 @@
 #define far
 #endif
 
+#include <cstdio>
+
 constexpr unsigned int coms = 24; // new element included
 //#define coms 23
 
@@ -202,7 +204,7 @@ extern int vicini;
 extern int sta_suonando;
 extern int pixel_sonante;
 
-extern int recfile;
+extern FILE* recfile;
 
 extern double cox, coy, coz;
 extern char justloaded;

--- a/include/global.h
+++ b/include/global.h
@@ -23,6 +23,13 @@
 #define far
 #endif
 
+// provide strcasecmp to msvc
+#ifdef _MSC_VER
+#include <string.h>
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+#endif
+
 #include <cstdio>
 
 constexpr unsigned int coms = 24; // new element included

--- a/include/sdl_exception.h
+++ b/include/sdl_exception.h
@@ -2,7 +2,7 @@
 #define SDL_EXCEPTION_H_INCLUDED
 
 #include <exception>
-#include <SDL2/SDL.h>
+#include "SDL.h"
 
 /** Class for defining an SDL exception.
  * This is meant to be thrown right after a failed SDL operation.

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <random>
 #include <cstdlib>
-#include <unistd.h>
+#include <cstdio>
 #include <fcntl.h>
 #include <cmath>
 #include <cstring>
@@ -897,8 +897,8 @@ noang:
                 // backdrop
                 strcpy (dist, &subsignal[9*pixeltype[pix]]);
                 strcat (dist, ".ATM");
-                a = open (dist, 0);
-                if (a>-1) {
+                FILE* file = std::fopen(dist, "rb");
+                if (file) {
                     // -- draw operation begin
                     auto ax = 360u;
                     ax -= beta;
@@ -923,15 +923,15 @@ noang:
                     cx = ax >> 16; // cx = ax >> 16
                     dx = ax;
                     dx += si;
-                    lseek(a, dx, SEEK_SET);
+                    std::fseek(file, dx, SEEK_SET);
                     auto p_data = &video_buffer[0];
                     si = 8;
                     do {
                         cx = WIDTH*HEIGHT / 8;
-                        read(a, p_data, cx);
+                        std::fread(p_data, 1, cx, file);
                         p_data += WIDTH*HEIGHT / 8;
                     } while (--si != 0);
-                    close (a);
+                    std::fclose (file);
                     // -- draw operation end
 
                     if (d>500) {
@@ -1537,11 +1537,11 @@ void read_args(int argc, char** argv, char& flag, char& sit)
         }
     }
     else if (argc == 2) {
-        if (argc==2) sit = argv[1][0];
+        sit = argv[1][0];
         sprintf (dist, "CRYXTELS.%cIT", sit);
-        int fh = open(dist, 0);
-        if (fh >= 0) {
-            close (fh);
+        FILE* fh = std::fopen(dist, "rb");
+        if (fh) {
+            std::fclose (fh);
             flag = 1;
         } else {
             _80_25_C();
@@ -2175,10 +2175,11 @@ void alfin (char arc)
 {
         if (arc) fade ();
         //dsp_driver_off (); // unused right now
-        if (recfile>-1) {
+        if (recfile) {
                 //audio_stop (); // unused right now
-                write (recfile, "\0",1);
-                close (recfile);
+                std::fwrite("\0", 1, 1, recfile);
+                std::fclose(recfile);
+                recfile = nullptr;
         }
         //file_driver_off ();
         _80_25_C ();
@@ -3142,7 +3143,7 @@ ogg_2:
 
 void Object (int tipo)
 {
-    int th;
+    FILE* th;
 
     switch (tipo) {
         case 0:
@@ -3172,7 +3173,7 @@ void Object (int tipo)
                 rel (-_ox, 0, _oy, _ox, 0, -_oy);
             }
             rectrel (0, 0, 0, 6, 6, 1);
-            if (recfile>-1) Txt ("> RECORD >", -5.5, 0, -5, 0.1, 0.15, 270, 0);
+            if (recfile) Txt ("> RECORD >", -5.5, 0, -5, 0.1, 0.15, 270, 0);
             if (globalvocfile[0]!='.') Txt ("> PLAY >", -5.5, 0, -4, 0.1, 0.15, 270, 0);
             sprintf (t, "INPUT: %s", source_name[static_cast<int>(source)]);
             Txt (t, -5.5, 0, 5, 0.1, 0.15, 270, 0);
@@ -3188,11 +3189,11 @@ void Object (int tipo)
                 a = subsignal[9*(tipo+FRONTIER_M3)+5/*6*/];
                 memset (buffer, ' ', 512);
                 sprintf (autore_forme, "TEXT-%03u.FIX", tipo-3);
-                th = open (autore_forme, O_CREAT|O_RDWR /*4*/,
-                        S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
-                if (th>-1) {
+                th = std::fopen (autore_forme, "a+b");
+                if (th) {
+                    std::fseek(th, 0, SEEK_SET);
                     buffer[32] = 0; k1 = 5.32;
-                    read (th, buffer+33, 512);
+                    std::fread(buffer+33, 512, 1, th);
                     for (c=0; c<512; c+=32) {
                         memcpy (buffer, buffer+33+c, 32);
                         if (a=='V') Txt (reinterpret_cast<char*>(buffer), -6.82, -k1, 0, 0.11, 0.14, 0, 0);
@@ -3262,17 +3263,17 @@ void Object (int tipo)
                     if (a=='V') Txt ("*", -6.82+(cursore%32)*0.44, (cursore/32)*0.7-5.32, 0, 0.5, 0.5, 0, 0);
                     else if (a=='H') Txt ("*", -6.82+(cursore%32)*0.44, 0, 5.32-(cursore/32)*0.7, 0.5, 0.5, 270, 0);
                     if (memcmp (buffer+33, buffer+545, 512)) {
-                        lseek (th, 0, SEEK_SET);
-                        write (th, buffer+33, 512);
+                        std::fseek (th, 0, SEEK_SET);
+                        std::fwrite (buffer+33, 512, 1, th);
                     }
                 //}
-                    close (th);
+                    std::fclose (th);
                 }
                 else {
-                    th = creat (autore_forme, 0);
-                    if (th>-1) {
-                        write (th, buffer, 512);
-                        close (th);
+                    th = std::fopen(autore_forme, "wb");
+                    if (th) {
+                        std::fwrite (buffer, 512, 1, th);
+                        std::fclose (th);
                     }
                 }
         }

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -39,7 +39,7 @@
 #include "input.h"
 #include "sdl_exception.h"
 
-#include <SDL2/SDL.h>
+#include "SDL.h"
 #include "conf.h"
 
 #ifndef far

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -15,6 +15,7 @@
  *  along with the program. If not, see <http://www.gnu.org/licenses/>.
  */
 #include "global.h"
+#include <cstdio>
 
 bool type_mode = false; // using type mode flag instead of scroll lock
 char type_this = 0; // character to type in the keyboard
@@ -251,7 +252,7 @@ int vicini = 0;
 int sta_suonando = -1;
 int pixel_sonante = -1;
 
-int recfile = -1;
+FILE* recfile = nullptr;
 
 double cox = 0, coy = 0, coz = 0;
 char justloaded = 5;

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -91,6 +91,39 @@ public:
     }
 };
 
+// Based on https://stackoverflow.com/a/27304609/1233251
+const char* stristr(const char* haystack, const char* needle) {
+    const char* p1 = haystack;
+    const char* p2 = needle;
+    const char* r = *p2 == 0 ? haystack : 0;
+
+    while (*p1 != 0 && *p2 != 0) {
+        if (tolower((unsigned char)*p1) == tolower((unsigned char)*p2)) {
+            if (r == 0) {
+                r = p1;
+            }
+
+            p2++;
+        } else {
+            p2 = needle;
+            if (r != 0) {
+                p1 = r + 1;
+            }
+
+            if (tolower((unsigned char)*p1) == tolower((unsigned char)*p2)) {
+                r = p1;
+                p2++;
+            } else {
+                r = 0;
+            }
+        }
+
+        p1++;
+    }
+
+    return *p2 == 0 ? (const char*)r : 0;
+}
+
 // aspetta un tasto e d qual'.
 int attendi_pressione_tasto ()
 {
@@ -166,11 +199,11 @@ char trova_id (FILE* fh, const char *id) {
     std::fseek(fh, 0, SEEK_SET);
 
     while (1) {
-        char *idpos;
+        const char *idpos;
 
         int cl = std::fread(buffer, 1, 1024, fh);
         buffer[cl-1] = '\0';
-        if ((idpos = strcasestr ((char*)buffer, id)) != NULL) {
+        if ((idpos = stristr ((const char*)buffer, id)) != NULL) {
             int dlt = (unsigned char*)idpos - buffer;
             int spostam = (int)strlen(id)-(cl-dlt);
             std::fseek (fh, spostam, SEEK_CUR);

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -27,7 +27,7 @@
 #include "global.h"
 #include "conf.h"
 #include "sdl_exception.h"
-#include <SDL2/SDL.h>
+#include "SDL.h"
 
 using namespace std;
 


### PR DESCRIPTION
- Tweak CMake to accept  `#include "SDL.h"` and link `SDL2main` explicitly
- remove use of "unistd.h", use cstdio for all file I/O instead
- make `strcasecmp` available to MSVC
- remove use of nonstandard `strcasestr`, provide definition of `stristr` instead