### PR TITLE
Gameplay tweaks

### DIFF
--- a/include/conf.h
+++ b/include/conf.h
@@ -20,6 +20,7 @@
 #define CONF_H_INCLUDED
 
 #include "SDL.h"
+constexpr int INTRO_FRAMES_PER_SECOND = 20;
 constexpr int FRAMES_PER_SECOND = 30;
 
 constexpr unsigned int WIDTH = 320;

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -75,7 +75,7 @@ void toggle_fullscreen();
 inline void _80_25_C () {} // modo grafico 80x25 testo a colori.
 
 /// Darken the screen once.
-void darken_once(void);
+void darken_once(unsigned char inc = 1);
 
 /// Render
 void Render (void);

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -50,6 +50,7 @@ using namespace std;
 
 constexpr int TICKS_IN_A_SECOND = 1000;
 constexpr int TICKS_PER_FRAME = TICKS_IN_A_SECOND / FRAMES_PER_SECOND;
+constexpr int INTRO_TICKS_PER_FRAME = TICKS_IN_A_SECOND / INTRO_FRAMES_PER_SECOND;
 
 // dummy function (nullify effect)
 inline void play (long) {}
@@ -389,7 +390,7 @@ int main(int argc, char** argv)
         Render();
 
         unsigned long cticks = SDL_GetTicks();
-        while (sync + TICKS_PER_FRAME > cticks) {
+        while (sync + INTRO_TICKS_PER_FRAME > cticks) {
             SDL_Delay(3);
             cticks = SDL_GetTicks();
         }

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1825,6 +1825,9 @@ halt:   keybuffer_cleaner ();
 }
 
 void load_situation(char i, bool skip_fade) {
+    if (i >= 'a' && i <= 'z') {
+        i -= 'a' - 'A';
+    }
     try {
         load_game(i);
         cout << "Game [" << i << "] successfully loaded." << endl;
@@ -1850,6 +1853,9 @@ void load_situation(char i, bool skip_fade) {
 }
 
 void save_situation(char i) {
+    if (i >= 'a' && i <= 'z') {
+        i -= 'a' - 'A';
+    }
     try {
     save_game(i);
         cout << "Game [" << i << "] successfully saved." << endl;

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -82,7 +82,7 @@ void dists ();
 void rot ();
 
 /// Fade out effect of the display.
-void fade ();
+void fade (unsigned char speed = 1);
 
 /// Docking effects.
 void dock_effects ();
@@ -403,7 +403,7 @@ int main(int argc, char** argv)
             load_situation(sit);
     else {
             cam_z = -20000;
-            fade ();
+            fade (3);
     }
 
     int rclick = 0;
@@ -1773,15 +1773,15 @@ void rot ()
     }
 }
 
-void fade ()
-{
+/// enter a synchronous routine
+/// to fade out the screen
+/// (can be skipped by pressing any key)
+void fade (unsigned char speed) {
     keybuffer_cleaner ();
-//rip:
     unsigned int dx = 0;
     auto skip = false;
-    unsigned int sync;
     do {
-        sync = SDL_GetTicks();
+        unsigned int sync = SDL_GetTicks();
 
         SDL_Event event;
         while (SDL_PollEvent(&event)) {
@@ -1791,7 +1791,7 @@ void fade ()
             }
         }
 
-        darken_once();
+        darken_once(speed);
         Render();
         unsigned long cticks = SDL_GetTicks();
         while (sync + TICKS_PER_FRAME > cticks) {
@@ -1799,7 +1799,7 @@ void fade ()
             cticks = SDL_GetTicks();
         }
     }
-    while(!skip && dx++ < 100);
+    while(!skip && dx++ < (100 / speed));
 /*
 rip:    mpul = 0; mouse_input ();
         _BL = tasto_premuto ();
@@ -1827,7 +1827,7 @@ void load_situation(char i) {
     try {
         load_game(i);
         cout << "Game [" << i << "] successfully loaded." << endl;
-        fade ();
+        fade (2);
         rot ();
         dists ();
         dock_effects ();
@@ -2177,7 +2177,7 @@ void chiudi_filedriver ()
 
 void alfin (char arc)
 {
-        if (arc) fade ();
+        if (arc) fade (5);
         //dsp_driver_off (); // unused right now
         if (recfile) {
                 //audio_stop (); // unused right now

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1933,10 +1933,10 @@ void ispd ()
     } else {
         _x = rel_x;
         _z = rel_z;
-        double acount = (SDL_GetTicks() % 520) + 560.0;
+        int acount = (SDL_GetTicks() % 520) / 4 - 80;
         // Sound off
         //if (acount<0&&!sbp_stat) play (PASSO);
-        rel_y = acount / 280.0;
+        rel_y += acount / 300.0;
         rel_x -= 4 * tsin[beta] * tcos[alfa];
         rel_z += 4 * tcos[beta] * tcos[alfa];
         if (docksite_h[pixeltype[pix]]>=0) {

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -92,7 +92,7 @@ void dock_effects ();
 void save_situation (char i);
 
 /// Load state
-void load_situation (char i);
+void load_situation (char i, bool skip_fade = false);
 
 /// Just makes the program exit because of something...
 void par0 (int el, int pix);
@@ -401,7 +401,7 @@ int main(int argc, char** argv)
 //    ignentra: //push_audiofile ("ECHO");
 
     if (flag)
-            load_situation(sit);
+            load_situation(sit, true);
     else {
             cam_z = -20000;
             fade (3);
@@ -1824,11 +1824,13 @@ halt:   keybuffer_cleaner ();
 */
 }
 
-void load_situation(char i) {
+void load_situation(char i, bool skip_fade) {
     try {
         load_game(i);
         cout << "Game [" << i << "] successfully loaded." << endl;
-        fade (2);
+        if (!skip_fade) {
+            fade (2);
+        }
         rot ();
         dists ();
         dock_effects ();

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1918,25 +1918,24 @@ void dists ()
     }
 }
 
+/// walk forward in the pixel
 void ispd ()
 {
-    int acount;
 
     if (trackframe&&!extra) return;
     if (!extra&&trackframe<23) {
         //spd = 2*spd + 1;
         spd = 1.5*spd + 0.5;
         if (spd>300) spd = 300;
-    }
-    else {
+    } else {
         _x = rel_x;
         _z = rel_z;
-        acount = (double)(SDL_GetTicks()%(FRAMES_PER_SECOND/4)) - 4;
+        double acount = (SDL_GetTicks() % 520) + 560.0;
         // Sound off
         //if (acount<0&&!sbp_stat) play (PASSO);
-        rel_y += (double)acount / 5;
-        rel_x -= /* 4 */ 2 * tsin[beta] * tcos[alfa];
-        rel_z += /* 4 */ 2 * tcos[beta] * tcos[alfa];
+        rel_y = acount / 280.0;
+        rel_x -= 4 * tsin[beta] * tcos[alfa];
+        rel_z += 4 * tcos[beta] * tcos[alfa];
         if (docksite_h[pixeltype[pix]]>=0) {
             if (rel_x>docksite_w[pixeltype[pix]]-docksite_x[pixeltype[pix]]) rel_x = docksite_w[pixeltype[pix]]-docksite_x[pixeltype[pix]];
             if (rel_x<-docksite_x[pixeltype[pix]]-docksite_w[pixeltype[pix]]) rel_x = -docksite_x[pixeltype[pix]]-docksite_w[pixeltype[pix]];
@@ -1958,6 +1957,7 @@ void ispd ()
     }
 }
 
+/// walk backward in the pixel
 void dspd ()
 {
         if (trackframe&&!extra) return;

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -126,14 +126,16 @@ void init_video () // inizializza grafica a 320x200x256 colori.
 }
 
 /// Darken the screen once.
-void darken_once (void) {
+void darken_once (unsigned char inc) {
     unsigned char* it = &video_buffer[0];
     unsigned int cx = WIDTH*HEIGHT;
 
     do {
         auto k = *it;
-        if (k != 0) {
-             *it = k-1;
+        if (k >= inc) {
+             *it = k - inc;
+        } else if (k > 0) {
+            *it = 0;
         }
         ++it;
     } while(--cx != 0);


### PR DESCRIPTION
These are a few tweaks to the game in order to make its experience a bit nicer, and in part closer to that of the English version of the original.

- increase the forward movement of the player when in a pixel
- tweak the up and down movements to be more consistent and closer to the original
- reduce the frame rate of the introduction screen to 20 FPS, as per the original
- increase the speed of screen fade out (a bit closer to the English version, but not as fast)
- skip unnecessary fade-out when loading a saved game from the command line (the current behavior already is to skip the introduction entirely)
- check for lowercase save letters earlier so as to report them to stdout in uppercase