### PR TITLE
Improve mouse/keyboard mode

### DIFF
--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -670,7 +670,6 @@ noang:
                         my = alfa * 5;
                         if (grab_mouse) {
                             SDL_SetRelativeMouseMode(m ? SDL_TRUE : SDL_FALSE);
-                            SDL_ShowCursor(m ? SDL_DISABLE : SDL_ENABLE);
 
                             // fetch mouse delta to discard past movement
                             SDL_GetRelativeMouseState(&mdltx, &mdlty);

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -481,7 +481,6 @@ int main(int argc, char** argv)
             mouse_input ();
 
             if (m && grab_mouse) { // Keep the mouse on the screen
-                //SDL_WarpMouse(WIDTH_SCALED/2, HEIGHT_SCALED/2);
                 mx += mdltx;
                 my += mdlty;
             }
@@ -669,7 +668,13 @@ noang:
                         betad = 0;
                         mx = beta * 5;
                         my = alfa * 5;
-                        //SDL_ShowCursor(m?SDL_DISABLE:SDL_ENABLE);
+                        if (grab_mouse) {
+                            SDL_SetRelativeMouseMode(m ? SDL_TRUE : SDL_FALSE);
+                            SDL_ShowCursor(m ? SDL_DISABLE : SDL_ENABLE);
+
+                            // fetch mouse delta to discard past movement
+                            SDL_GetRelativeMouseState(&mdltx, &mdlty);
+                        }
                         break;
                     default:
                         break;


### PR DESCRIPTION
- don't grab the mouse when in keyboard mode
   - orientation jump when entering mouse mode should now be fixed
- hide/show system cursor based on whether the game is grabbing the mouse
   - might still rethink this, because the mouse cursor might still be undesirable, especially in full screen
- clean up some other pieces of code