### PR TITLE
Stricter types

### DIFF
--- a/include/conf.h
+++ b/include/conf.h
@@ -20,17 +20,19 @@
 #define CONF_H_INCLUDED
 
 #include "SDL.h"
-constexpr int INTRO_FRAMES_PER_SECOND = 20;
-constexpr int FRAMES_PER_SECOND = 30;
+#include "primitives.h"
 
-constexpr unsigned int WIDTH = 320;
-constexpr unsigned int HEIGHT = 200;
+constexpr u32 INTRO_FRAMES_PER_SECOND = 20;
+constexpr u32 FRAMES_PER_SECOND = 30;
 
-constexpr unsigned int WIDTH_SC = 2;
-constexpr unsigned int HEIGHT_SC = 2;
+constexpr u32 WIDTH = 320;
+constexpr u32 HEIGHT = 200;
 
-constexpr unsigned int WIDTH_SCALED = WIDTH*WIDTH_SC;
-constexpr unsigned int HEIGHT_SCALED = HEIGHT*HEIGHT_SC;
+constexpr u32 WIDTH_SC = 2;
+constexpr u32 HEIGHT_SC = 2;
+
+constexpr u32 WIDTH_SCALED = WIDTH*WIDTH_SC;
+constexpr u32 HEIGHT_SCALED = HEIGHT*HEIGHT_SC;
 
 constexpr auto keymap_thrust    = SDLK_a;
 constexpr auto keymap_back      = SDLK_z;
@@ -41,14 +43,14 @@ constexpr auto keymap_right     = SDLK_RIGHT;
 
 /// The maximum number of pixels allowed ingame.
 /// This was hardcoded to 500 in the original version.
-constexpr auto MAX_PIXELS = 500;
+constexpr u32 MAX_PIXELS = 500;
 
 /// The maximum number of objects allowed ingame.
 /// This was hardcoded to 500 in the original version.
-constexpr auto MAX_OBJECTS = 500;
+constexpr u32 MAX_OBJECTS = 500;
 
 /// The maximum number of pixel types allowed ingame.
 /// This was hardcoded to 600 in the original version.
-constexpr auto MAX_PIXEL_TYPES = 650;
+constexpr u32 MAX_PIXEL_TYPES = 650;
 
 #endif // CONF_H_INCLUDED

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -21,6 +21,7 @@
 
 #include "SDL.h"
 #include <memory>
+#include "primitives.h"
 
 #ifndef far
 #define far
@@ -51,9 +52,9 @@ extern float *tcosy, *tsiny;
 extern double cam_x, cam_y, cam_z;
 
 /// Alpha and Beta (camera orientation)
-extern short int alfa,beta;
+extern i16 alfa,beta;
 
-/// Something...
+/// Distance to the closest pixel.
 extern double kk;
 
 /// Some position...
@@ -87,11 +88,6 @@ void snapshot (void);
 void tavola_colori (const unsigned char *new_palette,
 		    unsigned int starting_color, unsigned int nr_colors,
 		    char red_filter, char green_filter, char blue_filter);
-/* Original prototype:
-void tavola_colori (unsigned char *nuova_tavolozza,
-		    unsigned colore_di_partenza, unsigned nr_colori,
-		    char filtro_rosso, char filtro_verde, char filtro_blu);
-*/
 
 /// Copy a graphical page
 // Ultraveloce copia di pagina grafica.

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -30,7 +30,7 @@
 constexpr double Pi = 3.141592653589793238462643383;
 
 /// The software membory buffer to perform all rendering in.
-extern std::unique_ptr<unsigned char[]> video_buffer;
+extern std::unique_ptr<u8[]> video_buffer;
 
 ///// The SDL surface to show a scaled result.
 //extern SDL_Surface * p_surface_scaled;
@@ -76,7 +76,7 @@ void toggle_fullscreen();
 inline void _80_25_C () {} // modo grafico 80x25 testo a colori.
 
 /// Darken the screen once.
-void darken_once(unsigned char inc = 1);
+void darken_once(u8 inc = 1);
 
 /// Render
 void Render (void);
@@ -85,17 +85,17 @@ void Render (void);
 void snapshot (void);
 
 /// Create a palette table based on new_palette.
-void tavola_colori (const unsigned char *new_palette,
+void tavola_colori (const u8 *new_palette,
 		    unsigned int starting_color, unsigned int nr_colors,
-		    char red_filter, char green_filter, char blue_filter);
+		    i8 red_filter, i8 green_filter, i8 blue_filter);
 
 /// Copy a graphical page
 // Ultraveloce copia di pagina grafica.
-void pcopy (unsigned char *dest, const unsigned char *sorg);
+void pcopy (u8 *dest, const u8 *sorg);
 
 /// Clear a graphical page with a pattern
 // Ultraveloce cancella pagina grafica.
-void pclear (unsigned char far *target, unsigned char pattern);
+void pclear (u8 far *target, u8 pattern);
 
 /// Initialization of a table of trigonometric calculation results.
 // Inizializzazione.

--- a/include/global.h
+++ b/include/global.h
@@ -31,30 +31,54 @@
 #endif
 
 #include <cstdio>
+#include "primitives.h"
 
-constexpr unsigned int coms = 24; // new element included
-//#define coms 23
+/// Identifier for a pixel in the game
+/// (from 0 to 32768, -1 means no pixel or not defined).
+using PixelId = i16;
+
+/// Identifier for an object in the game
+/// (from 0 to 32768, -1 means no object or not defined).
+using ObjectId = i16;
+
+/// Identifier for a pixel type in the game
+/// (from 0 to 32768, -1 means no pixel type or not defined).
+using PixelTypeId = i16;
+
+/// Identifier for an object type in the game (from 0 to 32768, -1 means no object type).
+using ObjectTypeId = i16;
+
+/// The total number of different pixel primitives.
+/// (updated from the original 23, to include SOLIDBOX)
+constexpr unsigned int COMS = 24;
 
 extern bool type_mode; // using type mode flag instead of scroll lock
 extern char type_this; // character to type in the keyboard
 
-extern short int nav_a, nav_b;
+/// alpha angle of the Fly
+extern i16 nav_a;
+/// beta angle of the Fly
+extern i16 nav_b;
 
-extern char taking; // Flag: attempt of taking an object.
-extern short int carry_type; // Object type being carried (-1 = none).
+extern u8 taking; // Flag: attempt of taking an object.
+extern ObjectId carry_type; // Object type being carried (-1 = none).
 extern double trackframe; // Number of frames of the docking sequence.
-extern char reset_trackframe; // Flag: reset trackframe, please.
+extern u8 reset_trackframe; // Flag: reset trackframe, please.
 extern double tracking; // Increment value to trackframe.
-extern char req_end_extra; /* Flag: si richiede la fine dell'attivit
-                                 extraveicolare ed il rientro nella nave? */
+/// Counter for the number of frames of the Fly reentering sequence.
+extern u8 req_end_extra;
 
-extern short int alfad, betad; // Angular speed of x and y.
-extern short int alfa90, beta90; // Support for some calculations.
+extern i16 alfad, betad; // Angular speed of x and y.
+extern i16 alfa90, beta90; // Support for some calculations.
 
-extern char fid; // Flag: Orientation of the direction opposite to the current one...
-extern char lead; // Flag: Orientation of the leading direction...
-extern char orig; // Flag: Orientation towards Sunny (Solicchio)...
-extern char comera_m;
+extern u8 fid; // Flag: Orientation of the direction opposite to the current one...
+extern u8 lead; // Flag: Orientation of the leading direction...
+extern u8 orig; // Flag: Orientation towards Sunny (Solicchio)...
+
+// Mouse flags
+extern u8 m;
+/// Previous mouse flags
+extern u8 comera_m;
 
 extern double spd_x; // x component of the ship's velocity.
 extern double spd_y; // y component of the ship's velocity.
@@ -64,21 +88,22 @@ extern double spd; // ship's acceleration.
 extern double rel_x, rel_y, rel_z; /* Coordinates relative to the docking site,
                                extra-vehicular activities. */
 
-extern short int obj; // Nearest object for taking (-1 = none).
-extern char m; // Mouse pointer?
-extern char echo; // Echo flags
+extern ObjectId obj; // Nearest object for taking (-1 = none).
+extern u8 echo; // Echo flags
 
-extern short int carried_pixel; // Pixel being carried (only considered in Sunny (Solicchio)).
+extern PixelId carried_pixel; // Pixel being carried (only considered in Sunny (Solicchio)).
 
 extern double disl; // dislivello incontrato da un passo all'altro.
 
-extern short int cursore; // Sulle lavagnette.
+/// Cursor position on a text board.
+extern u16 cursore;
 
-extern char explode_count; // Durante gli scoppii.
+/// Counter for explosion sequence.
+extern u8 explode_count;
 
 extern char repeat; // Ripetizione brani dai CD virtuali.
 extern char source; // Sorgente di registrazione selezionata.
-extern char quality; // Qualit dell'incisione.
+extern char quality; // Qualità dell'incisione.
 
 
 extern unsigned char ctk;
@@ -88,16 +113,20 @@ extern char subs;
 extern double prevpixx;
 extern double prevpixz;
 
-extern short int existent_pixeltypes; // Existent pixel types.
-extern short int existent_objecttypes; // Existent object types.
+/// Total number of existent pixel types
+/// according to the pixel definitions.
+extern u16 existent_pixeltypes;
+// Total number of existent object types
+/// according to the pixel definitions.
+extern u16 existent_objecttypes;
 
 /* Dati sui pixels. */
 
-extern short int pixels; // Total nr. of pixels (not initialized).
+extern u16 pixels; // Total nr. of pixels (not initialized).
 
-extern short int far *pixeltype; // Pixel type array, from 0 to existent_pixeltypes-1.
+extern PixelTypeId far *pixeltype; // Pixel type array, from 0 to existent_pixeltypes-1.
 
-extern unsigned char far *pixel_rot; // Rotation around Sunny flag.
+extern u8 far *pixel_rot; // Rotation amount around Sunny flag.
 
 extern float far  *pixel_absd;    // Absolute distance from the observer.
 extern double far *pixel_support; // Support for which pixel (in memory).
@@ -125,18 +154,20 @@ extern const int MEMORIA_RICHIESTA;
 /* Descriptions of each pixel type
    (<BUFFERS> tipi caricati per volta, <ELEMS> element per type). */
 
-extern unsigned char far *buffer; // Buffer for retrieving Id's.
+extern u8* buffer; // A multi-purpose piece of memory.
 
-extern char loaded_pixeltypes;       // Loaded pixel types.
+/// Number of loaded pixel types.
+extern u8 loaded_pixeltypes;
 
-extern short int far *pixeltype_type;      // What pixel type is defined for that pixel?
-extern unsigned char far *pixeltype_elements; // How many elements are defined for that pixel?
+extern PixelTypeId* pixeltype_type;      // What pixel type is defined for that pixel?
+extern u8*  pixeltype_elements; // How many elements are defined for that pixel type?
 
-extern const char *comspec[];
+/// The names of the primitives.
+extern const char *comspec[COMS];
 
-extern char params[coms];
+extern const u8 params[COMS];
 
-extern unsigned char far *pixel_elem_t;   // Element types. size = ELEMS*BUFFERS
+extern u8 far *pixel_elem_t;   // Element types. size = ELEMS*BUFFERS
 
 extern double far *pixel_elem_x; // Coordinates relative to pixel.
 extern double far *pixel_elem_y;
@@ -155,11 +186,16 @@ extern float  far *pixel_elem_4;
 extern char far *pixel_elem_b;
 
 // Position of the docking type for each pixel type.
-extern float far *docksite_x;  
+
+/// X coordinate of each pixel's dock site
+extern float far *docksite_x;
+/// Y coordinate of each pixel's dock site
 extern float far *docksite_y;
+/// Z coordinate of each pixel's dock site
 extern float far *docksite_z;
-// Width and Depth.
+/// Dock site width for each pixel.
 extern float far *docksite_w;
+/// Dock site height for each pixel.
 extern float far *docksite_h;
 
 // Pixel mass
@@ -170,17 +206,17 @@ extern char far *subsignal;
 
 /* Concerning objects. */
 
-extern short int objects; // Total nr. of objects (not initialized).
-extern short int _objects; // Variable used when cycling for the total number of objects.
+extern u16 objects; // Total nr. of objects (not initialized).
+extern u16 _objects; // Variable used when cycling for the total number of objects.
 
-extern short int  *objecttype;      // Object type.
+extern ObjectTypeId  *objecttype;      // Object type.
 extern double far *relative_x;      // Position X (relative to pixel).
 extern double far *relative_y;      // Position Y (relative to pixel).
 extern double far *relative_z;      // Position Z (relative to pixel).
 extern double far *absolute_x;      // Position X (absolute for Pixel = -1).
 extern double far *absolute_y;      // Position Y (absolute for Pixel = -1).
 extern double far *absolute_z;      // Position Z (absolute for Pixel = -1).
-extern short int  *object_location; // Pixel where the object can be retrieved.
+extern PixelId  *object_location; // Pixel where the object can be retrieved.
 
 /* IMPORTANT: the object's elevation at the pixel's surface for each object type.
  */
@@ -190,17 +226,22 @@ extern double object_collyblockshifting[203];
 
 // Varied support.
 
-extern short int pix; // Pixel pi vicino (ecoscandaglio, attracco automatico...)
+/// ID of the current closest pixel.
+extern PixelId pix;
 
-extern char extra; // Flag: attivit extraveicolare in corso?
+/// Flag: 1 = extravehicular activity (walking on a pixel); 0 = on Fly
+extern u8 extra;
 
 extern double r_x, r_y, r_z; // Posizioni relat. al pixel, per il fotogr. precedente.
 extern double dsx, dsy, dsz; // Posizioni reali del docksite del pixel-bersaglio.
 extern double cam_xt, cam_yt, cam_zt; // Posizioni <teoriche> dell'osservatore.
 extern double _x, _y, _z, _ox, _oy, _oz; // Temporanee nei disegni.
 
-extern double nav_x; // Coordinate di The Fly.
+/// X coordinate of The Fly
+extern double nav_x;
+/// Y coordinate of The Fly
 extern double nav_y;
+/// Z coordinate of The Fly
 extern double nav_z;
 
 extern double d; // Distanza generica.
@@ -214,16 +255,19 @@ extern char globalvocfile[13]; // sottofondi sui pixels.
 
 extern char fermo_li;
 
+/// whether the sound emitting object is close
 extern int vicini;
 extern int sta_suonando;
-extern int pixel_sonante;
+/// ID of the pixel emitting sound.
+extern PixelId pixel_sonante;
 
 extern FILE* recfile;
 
 extern double cox, coy, coz;
-extern char justloaded;
+extern u8 justloaded;
 
-extern char moving_last_object; // Sta spostando l'ultimo oggetto lasciato.
+/// Whether the last object moved is still being dropped.
+extern u8 moving_last_object; // Sta spostando l'ultimo oggetto lasciato.
 extern double cfx, cfy, cfz; // Carried-Final-relative-X/Y/Z (dove deve andare /\).
 
 extern const char *source_name[];

--- a/include/input.h
+++ b/include/input.h
@@ -19,8 +19,9 @@
 
 #include <array>
 #include <memory>
+#include "global.h"
 
-extern std::array<unsigned char,2> ctrlkeys;
+extern std::array<u8, 2> ctrlkeys;
 //extern int fh;
 
 extern const char* loaded_background;
@@ -51,11 +52,11 @@ void Archivia_Situazione (char i);
 //void leggi_t_fino_a (char codcar, int ptyp);
 
 /// Load PIXELS.DEF
-void load_pixels_def(int& ptyp);
+void load_pixels_def(void);
 
 // Carica il tipo di pixel specificato.
 /// Load the specified pixel type
-void LoadPtyp (int ptyp);
+void LoadPtyp (PixelTypeId ptyp);
 
 
 /// Load a saved game

--- a/include/primitives.h
+++ b/include/primitives.h
@@ -1,0 +1,41 @@
+/** \file primitives.h
+ *  This file is part of Crystal Pixels.
+ *
+ *  Crystal Pixels is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Crystal Pixels is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the program. If not, see <http://www.gnu.org/licenses/>.
+ */
+// Concise and useful primitive types to use throughout the code base.
+#ifndef PRIMITIVES_H_INCLUDED
+#define PRIMITIVES_H_INCLUDED
+
+#include <cstdint>
+
+/// 8-bit unsigned integer
+using u8 = uint8_t;
+/// 8-bit signed integer
+using i8 = int8_t;
+/// 16-bit unsigned integer
+using u16 = uint16_t;
+/// 16-bit signed integer
+using i16 = int16_t;
+/// 32-bit unsigned integer
+using u32 = uint32_t;
+/// 32-bit signed integer
+using i32 = int32_t;
+
+/// 32-bit floating point
+using f32 = float;
+/// 64-bit floating point
+using f64 = double;
+
+#endif

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -319,16 +319,16 @@ int main(int argc, char** argv)
 //          pusha
 //          les di, dword ptr adapted
             auto di = &video_buffer[0];
-            unsigned short i = 0;
+            u16 i = 0;
 //          xor ah, ah
 //          int 1ah
             // this is used to get the clock ticks
 //          xor dh, dh
-            unsigned int dx = (SDL_GetTicks()/TICKS_PER_FRAME) & 0xFFFF; //% WIDTH;
+            u32 dx = (SDL_GetTicks()/TICKS_PER_FRAME) & 0xFFFF; //% WIDTH;
 //          add di, dx
             i = dx;
 //          mov cx, 16000 }
-            unsigned int cx = (WIDTH*HEIGHT) >> 2;
+            u32 cx = (WIDTH*HEIGHT) >> 2;
             do {
 //  _chic:
 //          asm {
@@ -1621,19 +1621,19 @@ inline bool allocation_farm()
     pixel_ydisloc = x_farmalloc<double> (MAX_PIXELS);
     pixel_zdisloc = x_farmalloc<double> (MAX_PIXELS);
 
-    objecttype = x_farmalloc<short> (MAX_OBJECTS);
+    objecttype = x_farmalloc<i16> (MAX_OBJECTS);
     relative_x = x_farmalloc<double> (MAX_OBJECTS);
     relative_y = x_farmalloc<double> (MAX_OBJECTS);
     relative_z = x_farmalloc<double> (MAX_OBJECTS);
     absolute_x = x_farmalloc<double> (MAX_OBJECTS);
     absolute_y = x_farmalloc<double> (MAX_OBJECTS);
     absolute_z = x_farmalloc<double> (MAX_OBJECTS);
-    object_location = x_farmalloc<short> (MAX_OBJECTS);
+    object_location = x_farmalloc<i16> (MAX_OBJECTS);
 
-    pixeltype_elements = x_farmalloc<unsigned char>(BUFFERS);
-    pixeltype_type = x_farmalloc<short> (BUFFERS);
+    pixeltype_elements = x_farmalloc<u8>(BUFFERS);
+    pixeltype_type = x_farmalloc<i16> (BUFFERS);
 
-    pixel_elem_t = x_farmalloc<unsigned char> (ELEMS*BUFFERS);
+    pixel_elem_t = x_farmalloc<u8> (ELEMS*BUFFERS);
     pixel_elem_x = x_farmalloc<double> (ELEMS*BUFFERS);
     pixel_elem_y = x_farmalloc<double> (ELEMS*BUFFERS);
     pixel_elem_z = x_farmalloc<double> (ELEMS*BUFFERS);
@@ -1650,7 +1650,7 @@ inline bool allocation_farm()
     docksite_h = x_farmalloc<float>(MAX_PIXEL_TYPES);
     subsignal = x_farmalloc<char> (9 * MAX_PIXEL_TYPES);
 
-    buffer = x_farmalloc<unsigned char> (1057);
+    buffer = x_farmalloc<u8> (1057);
     } catch (const int&) {
         return false;
     }

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <cassert>
 #include "global.h"
+#include "primitives.h"
 #include "fast3d.h"
 #include "text3d.h"
 #include "input.h"
@@ -66,8 +67,10 @@ inline bool allocation_farm();
 void read_args(int argc, char** argv, char& flag, char& sit);
 
 // Aggiorna il buffer dei pixels caricati.
-/// Update buffer with loaded pixels
-void cerca_e_carica (int typ);
+/// Updates buffer with loaded pixels:
+/// Search for the pixel type of ID `typ`
+/// and load it if it is not loaded yet.
+void cerca_e_carica (PixelTypeId typ);
 
 /// build the cosmos
 void build_cosm(char& flag);
@@ -83,7 +86,7 @@ void dists ();
 void rot ();
 
 /// Fade out effect of the display.
-void fade (unsigned char speed = 1);
+void fade (u8 speed = 1);
 
 /// Docking effects.
 void dock_effects ();
@@ -189,7 +192,7 @@ void lead_on ();
 void orig_on ();
 
 /// Generate the color palette
-void tinte (unsigned char satu);
+void tinte (u8 satu);
 
 /// Explode
 void scoppia (int nr_ogg, double potenza, int var);
@@ -198,7 +201,7 @@ void scoppia (int nr_ogg, double potenza, int var);
 void chiudi_filedriver ();
 
 /// Fottifoh object model
-extern char fotty[277];
+extern i8 fotty[277];
 
 int main(int argc, char** argv)
 {
@@ -209,7 +212,6 @@ int main(int argc, char** argv)
     char flag = 0;
     //char sit = 'S'; // < the original would auto-load the default game save (Alex's save)
     char sit = 0;
-    int ptyp = 0;
     try {
         init_start();
 
@@ -217,7 +219,7 @@ int main(int argc, char** argv)
 
         read_args(argc, argv, flag, sit);
 
-        load_pixels_def(ptyp);
+        load_pixels_def();
 
         build_cosm(flag);
 
@@ -480,7 +482,7 @@ int main(int argc, char** argv)
             mpul = 0;
             mouse_input ();
 
-            if (m && grab_mouse) { // Keep the mouse on the screen
+            if (m && grab_mouse) {
                 mx += mdltx;
                 my += mdlty;
             }
@@ -1609,9 +1611,9 @@ inline bool allocation_farm()
     try {
     pixel_elem_b = x_farmalloc<char>(40*ELEMS*BUFFERS);
 
-    pixeltype = x_farmalloc<short> (MAX_PIXELS);
+    pixeltype = x_farmalloc<PixelTypeId> (MAX_PIXELS);
     pixelmass = x_farmalloc<float> (MAX_PIXEL_TYPES); // 2600
-    pixel_rot = x_farmalloc<unsigned char>(MAX_PIXELS * 2);
+    pixel_rot = x_farmalloc<u8>(MAX_PIXELS * 2);
 
     pixel_absd = x_farmalloc<float>(MAX_PIXELS);
     pixel_support = x_farmalloc<double> (MAX_PIXELS);
@@ -1891,12 +1893,9 @@ void save_situation(char i) {
     }
 }
 
-void cerca_e_carica (int typ)
-{
-    int iii;
-
+void cerca_e_carica (PixelTypeId typ) {
     if (loaded_pixeltypes) {
-        for (iii = 0; iii<loaded_pixeltypes; iii++) {
+        for (auto iii = 0u; iii<loaded_pixeltypes; iii++) {
             if (typ==pixeltype_type[iii])
                 return;
         }
@@ -3344,7 +3343,7 @@ void Object (int tipo)
 
 // Disegna la forma di un oggetto.
 
-char fotty[277] = {
+i8 fotty[277] = {
         -6, 0, +6,          -4, 0, +8,
         -4, 0, +8,          -2, 0, +8,
         -2, 0, +8,          -2, 0, +6,

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1305,13 +1305,13 @@ noang:
     sprintf (dist, "F=%04d/CGR", (int)spd);
     nTxt (dist, -5.5, 4.5, 12.01, 0.07, 0.12);
 
-    if (!trackframe) sprintf (dist, "V=%04.0f:K/H", (float)veloc*1.9656);
+    if (!trackframe) sprintf (dist, "V=%04.0f:K/H", veloc*1.9656);
     else sprintf (dist, "--DOCKED--" /*"ATTRACCATO"*/);
     nTxt (dist, -5.5, 5.4, 12.01, 0.07, 0.12);
 
-    sprintf (dist, "ASC=%03d`", nav_b);
+    sprintf (dist, "ASC=%03hd`", nav_b);
     nTxt (dist, -2.25, 4.5, 12.01, 0.07, 0.12);
-    sprintf (dist, "DEC=%03d`", nav_a);
+    sprintf (dist, "DEC=%03hd`", nav_a);
     nTxt (dist, -2.25, 5.4, 12.01, 0.07, 0.12);
 
     sprintf (dist, "H=%1.1f:KM", -cam_y/33333.33333);
@@ -3247,7 +3247,7 @@ void Object (int tipo)
                 memset (buffer, ' ', 512);
                 // safeguard buffer from reading beyond the end of the text
                 buffer[512] = '\0';
-                sprintf (autore_forme, "TEXT-%03u.FIX", tipo-3);
+                sprintf (autore_forme, "TEXT-%03d.FIX", tipo-3);
                 th = std::fopen (autore_forme, "r+b");
                 if (th) {
                     buffer[32] = '\0';

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -43,17 +43,15 @@ double cam_x = 0;
 double cam_y = 0;
 double cam_z = 0;
 
-short int alfa  = 0;
-short int beta  = 0;
+i16 alfa  = 0;
+i16 beta  = 0;
 
 double kk;
 double rx, ry, rz;
 double x2, y2, z2;
 double ox, oy, oz;
 
-//#define lwx 3
 const int lwx = 3;
-//#define lwy 3
 const int lwy = 3;
 
 const int zbasex = WIDTH * 2 / 3, zbasey = 150*HEIGHT/200;
@@ -61,13 +59,8 @@ const int nav_zbasex = WIDTH-2, nav_zbasey = HEIGHT-2;
 const int lowerbound_y = -static_cast<int>(HEIGHT/2-lwy), upperbound_y = static_cast<int>(HEIGHT/2-lwy);
 const int lowerbound_x = -static_cast<int>(WIDTH/2-lwx), upperbound_x = static_cast<int>(WIDTH/2-lwx);
 
-//#define upx 317
-const int upx = WIDTH - 3;
-//#define upy 197
-const int upy = HEIGHT - 3;
-
-int x_centro = WIDTH/2;
-int y_centro = HEIGHT/2;
+const u32 x_centro = WIDTH/2;
+const u32 y_centro = HEIGHT/2;
 
 double uneg = 1;
 double mindiff = 0.01;
@@ -281,12 +274,8 @@ void Segmento (unsigned int x, unsigned int y,
            unsigned int x2, unsigned int y2)
 {
     // Pre-conditions
-    SDL_assert(x >= 0);
-    SDL_assert(y >= 0);
     SDL_assert(x < WIDTH);
     SDL_assert(y < HEIGHT);
-    SDL_assert(x2 >= 0);
-    SDL_assert(y2 >= 0);
     SDL_assert(x2 < WIDTH);
     SDL_assert(y2 < HEIGHT);
 

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -27,7 +27,7 @@
 
 // Variables!
 //SDL_Surface * p_surface = nullptr;
-std::unique_ptr<unsigned char[]> video_buffer;
+std::unique_ptr<u8[]> video_buffer;
 
 SDL_Surface * p_surface_32 = nullptr;
 SDL_Surface * p_surface_scaled = nullptr;
@@ -66,7 +66,7 @@ double uneg = 1;
 double mindiff = 0.01;
 
 /// New Palette definition
-unsigned char tmppal[256 * 4]; // 256*4 bytes (RGBU)
+u8 tmppal[256 * 4]; // 256*4 bytes (RGBU)
 
 // Old Palette definition
 //unsigned char tmppal[768]; // 256*3 bytes (RGB)
@@ -119,7 +119,7 @@ void init_video () // inizializza grafica a 320x200x256 colori.
 }
 
 /// Darken the screen once.
-void darken_once (unsigned char inc) {
+void darken_once (u8 inc) {
     unsigned char* it = &video_buffer[0];
     unsigned int cx = WIDTH*HEIGHT;
 
@@ -174,9 +174,9 @@ void Render (void)
     SDL_RenderPresent(p_renderer);
 }
 
-void tavola_colori (const unsigned char *nuova_tavolozza,
+void tavola_colori (const u8 *nuova_tavolozza,
             unsigned int colore_di_partenza, unsigned int nr_colori,
-            char filtro_rosso, char filtro_verde, char filtro_blu)
+            i8 filtro_rosso, i8 filtro_verde, i8 filtro_blu)
 {
     constexpr unsigned int K_FILTER = 63; // original is 63
     unsigned int c, cc = 0;
@@ -198,18 +198,18 @@ void tavola_colori (const unsigned char *nuova_tavolozza,
 
     c = colore_di_partenza;
     while (c<nr_colori+colore_di_partenza) {
-        unsigned short temp = tmppal[c];
-        temp *= (unsigned char)filtro_rosso;
+        u16 temp = tmppal[c];
+        temp *= (u8)filtro_rosso;
         temp /= K_FILTER;
         tmppal[c] = temp;
         c++;
         temp = tmppal[c];
-        temp *= (unsigned char)filtro_verde;
+        temp *= (u8)filtro_verde;
         temp /= K_FILTER;
         tmppal[c] = temp;
         c++;
         temp = tmppal[c];
-        temp *= (unsigned char)filtro_blu;
+        temp *= (u8)filtro_blu;
         temp /= K_FILTER;
         tmppal[c] = temp;
         c+=2;
@@ -217,7 +217,7 @@ void tavola_colori (const unsigned char *nuova_tavolozza,
 }
 
 // This function is unsafe and should be removed
-void pcopy (unsigned char *dest, const unsigned char *sorg) {
+void pcopy (u8 *dest, const u8 *sorg) {
     // The old "it's assembly, so it's faster" ideology is
     // what will crack the skulls of future coders and is no
     // longer really true anyway.
@@ -228,7 +228,7 @@ void pcopy (unsigned char *dest, const unsigned char *sorg) {
 
 
 // This function is unsafe and should be removed
-void pclear (unsigned char *target, unsigned char pattern) {
+void pclear (u8 *target, u8 pattern) {
     // Again, let's just try something different.
     memset(target, pattern, WIDTH*HEIGHT*sizeof(*target));
 }
@@ -279,7 +279,7 @@ void Segmento (unsigned int x, unsigned int y,
     SDL_assert(x2 < WIDTH);
     SDL_assert(y2 < HEIGHT);
 
-    unsigned char* si = &video_buffer[0];
+    u8* si = &video_buffer[0];
 
     int temp;
     if (x==x2) {
@@ -290,7 +290,7 @@ void Segmento (unsigned int x, unsigned int y,
         unsigned int di = WIDTH*y + x;
         unsigned int _ax = WIDTH*y2;
         // now we're making a pointer to the scanline at y2
-        unsigned char* ax = si + _ax;
+        u8* ax = si + _ax;
         // now we'll make si point to the other scanline (y)
         si += di;
         while (si < ax) {

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -33,8 +33,8 @@ double tracking = 0; // Incremento a trackframe.
 u8 req_end_extra = 0; /* Flag: si richiede la fine dell'attività
                            extraveicolare ed il rientro nella nave? */
 
-short int alfad = 0, betad = 0; // Velocità angolare su assi x ed y.
-short int alfa90, beta90; // Supporti per alcuni calcoli.
+i16 alfad = 0, betad = 0; // Velocità angolare su assi x ed y.
+i16 alfa90, beta90; // Supporti per alcuni calcoli.
 
 u8 fid = 0; // Flag: Orientamento nella direzione opposta a quella corrente...
 u8 lead = 0; // Flag: Orientamento in direzione d'avanzamento...

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -22,48 +22,48 @@ char type_this = 0; // character to type in the keyboard
 
 /* Variabili di cima per allineamento e risparmio di istruzioni read/write. */
 
-short int nav_a = 0; // Inclinazione di The Fly.
-short int nav_b = 0;
+i16 nav_a = 0; // Inclinazione di The Fly.
+i16 nav_b = 0;
 
-char taking = 0; // Flag: tentativo di prelevamento di un oggetto.
-short int carry_type = -1; // Tipo oggetto trasportato (-1 = nessuno).
+u8 taking = 0; // Flag: tentativo di prelevamento di un oggetto.
+ObjectId carry_type = -1; // Tipo oggetto trasportato (-1 = nessuno).
 double trackframe = 0; // Nr. fotogramma della sequenza di attracco.
-char reset_trackframe = 0; // Flag: azzera trackframe, per favore.
+u8 reset_trackframe = 0; // Flag: azzera trackframe, per favore.
 double tracking = 0; // Incremento a trackframe.
-char req_end_extra = 0; /* Flag: si richiede la fine dell'attivit
+u8 req_end_extra = 0; /* Flag: si richiede la fine dell'attività
                            extraveicolare ed il rientro nella nave? */
 
-short int alfad = 0, betad = 0; // Velocit angolare su assi x ed y.
+short int alfad = 0, betad = 0; // Velocità angolare su assi x ed y.
 short int alfa90, beta90; // Supporti per alcuni calcoli.
 
-char fid = 0; // Flag: Orientamento nella direzione opposta a quella corrente...
-char lead = 0; // Flag: Orientamento in direzione d'avanzamento...
-char orig = 0; // Flag: Orientamento in direzione del Solicchio...
-char comera_m;
+u8 fid = 0; // Flag: Orientamento nella direzione opposta a quella corrente...
+u8 lead = 0; // Flag: Orientamento in direzione d'avanzamento...
+u8 orig = 0; // Flag: Orientamento in direzione del Solicchio...
+u8 comera_m;
 
-double spd_x = 0; // Componente x della velocit della nave.
-double spd_y = 0; // Componente y della velocit della nave.
-double spd_z = 0; // Componente z della velocit della nave.
+double spd_x = 0; // Componente x della velocità della nave.
+double spd_y = 0; // Componente y della velocità della nave.
+double spd_z = 0; // Componente z della velocità della nave.
 double spd = 0; // Accelerazione della nave.
 
 double rel_x, rel_y, rel_z; /* Coordinate relative al docksite per attivit
                                extraveicolare. */
 
-short int obj = -1; // Oggetto pi vicino da prelevare (-1 = nessuno).
-char m = 1; // Puntamento da mouse?
-char echo = 1; // Ecoscandaglio acceso?
+ObjectId obj = -1; // Oggetto più vicino da prelevare (-1 = nessuno).
+u8 m = 1; // Puntamento da mouse?
+u8 echo = 1; // Ecoscandaglio acceso?
 
-short int carried_pixel = -1; // Pixel trasportato (solo i DONI del Solicchio).
+PixelId carried_pixel = -1; // Pixel trasportato (solo i DONI del Solicchio).
 
 double disl = 0; // dislivello incontrato da un passo all'altro.
 
-short int cursore = 0; // Sulle lavagnette.
+u16 cursore = 0; // Sulle lavagnette.
 
-char explode_count = 0; // Durante gli scoppii.
+u8 explode_count = 0; // Durante gli scoppii.
 
 char repeat  = 0; // Ripetizione brani dai CD virtuali.
 char source  = 0; // Sorgente di registrazione selezionata.
-char quality = 0; // Qualit dell'incisione.
+char quality = 0; // Qualità dell'incisione.
 
 
 unsigned char ctk;
@@ -73,16 +73,16 @@ char subs = 1;
 double prevpixx;
 double prevpixz;
 
-short int existent_pixeltypes = 0; // Tipi di pixel esistenti (letti da disco).
-short int existent_objecttypes = 3; // Tipi di oggetto esistenti.
+u16 existent_pixeltypes = 0; // Tipi di pixel esistenti (letti da disco).
+u16 existent_objecttypes = 3; // Tipi di oggetto esistenti.
 
 /* Dati sui pixels. */
 
-short int pixels = 0; // Nr. totale dei pixels (non inizializzato).
+u16 pixels = 0; // Nr. totale dei pixels (non inizializzato).
 
-short int far *pixeltype; // Tipo di pixel, da 0 a existent_pixeltypes-1.
+PixelTypeId* pixeltype; // Tipo di pixel, da 0 a existent_pixeltypes-1.
 
-unsigned char far *pixel_rot; // Flag di rotazione attorno al Solicchio.
+u8* pixel_rot; // Flag di rotazione attorno al Solicchio.
 
 float far  *pixel_absd;    // Distanza assoluta dall'osservatore.
 double far *pixel_support; // Supporto per quel pixel (piccola memoria).
@@ -116,14 +116,14 @@ const int MEMORIA_RICHIESTA = 251901 + 81*ELEMS*BUFFERS + 3*BUFFERS;
 /* Descrizione dei tipi di pixel
    (<BUFFERS> tipi caricati per volta, <ELEMS> elementi per tipo). */
 
-unsigned char far *buffer; // Buffer per la ricerca degli Id.
+u8 *buffer; // Buffer per la ricerca degli Id.
 
-char loaded_pixeltypes;       // Tipi di pixel caricati.
+u8 loaded_pixeltypes;       // Tipi di pixel caricati.
 
-short int far *pixeltype_type;      // Che tipo di pixel ha questa definizione?
-unsigned char far *pixeltype_elements; // Quanti elementi contiene la definizione?
+PixelTypeId far *pixeltype_type;      // Che tipo di pixel ha questa definizione?
+u8 far *pixeltype_elements; // Quanti elementi contiene la definizione?
 
-const char *comspec[] = {
+const char* comspec[COMS] = {
 "ENDPIXEL", // FINEPIXEL
 "DETAIL", // DETTAGLIO
 "DOCK", // ATTRACCO
@@ -150,7 +150,8 @@ const char *comspec[] = {
 "SOLIDBOX" // new element in English version
 };
 
-char params[coms] = {
+/// The number of parameters expected for each primitive in a pixel definition.
+const u8 params[COMS] = {
 0,
 0,
 5,
@@ -177,7 +178,7 @@ char params[coms] = {
 6,
 };
 
-unsigned char far *pixel_elem_t;   // Tipo di elemento.
+u8* pixel_elem_t;   // Tipo di elemento.
 
 double far *pixel_elem_x; // Coordinate relative al pixel.
 double far *pixel_elem_y;
@@ -188,7 +189,7 @@ float  far *pixel_elem_3;
 float  far *pixel_elem_4;
 
 char far *pixel_elem_b;   /* Buffer testuale per la funzione TEXT (40 car.),
-                             il buffer contiene il testo, ma pu contenere
+                             il buffer contiene il testo, ma può contenere
                              l'id del pixel se nel testo viene inserito
                              il simbolo "%d", insieme ad eventuali caratteri.
                              Parametri per text, in ordine numerico da 0:
@@ -197,7 +198,7 @@ char far *pixel_elem_b;   /* Buffer testuale per la funzione TEXT (40 car.),
 float far *docksite_x;   // Posizione dei siti di attracco per ogni pixeltype.
 float far *docksite_y;
 float far *docksite_z;
-float far *docksite_w;   // Larghezza e Profondit.
+float far *docksite_w;   // Larghezza e Profondità.
 float far *docksite_h;
 
 float far *pixelmass; // Massa.
@@ -206,30 +207,30 @@ char far *subsignal; // Files per sottofondi audio.
 
 /* Dati sugli oggetti. */
 
-short int objects = 0; // Nr. totale degli oggetti (non inizializzato).
-short int _objects; // Variabile usata nei cicli come nr. totale di oggetti.
+u16 objects = 0; // Nr. totale degli oggetti (non inizializzato).
+u16 _objects; // Variabile usata nei cicli come nr. totale di oggetti.
 
-short int  *objecttype;      // Tipo d'oggetto.
+ObjectTypeId  *objecttype;      // Tipo d'oggetto.
 double far *relative_x;      // Posizione X (relativa a quella del Pixel).
 double far *relative_y;      // Posizione Y (relativa a quella del Pixel).
 double far *relative_z;      // Posizione Z (relativa a quella del Pixel).
 double far *absolute_x;      // Posizione X (assoluta per Pixel = -1).
 double far *absolute_y;      // Posizione Y (assoluta per Pixel = -1).
 double far *absolute_z;      // Posizione Z (assoluta per Pixel = -1).
-short int  *object_location; // Pixel su cui si trova l'oggetto.
+PixelId  *object_location; // Pixel su cui si trova l'oggetto.
 
 /* IMPORTANTE: elevazione sulla superficie del pixel
                per ogni tipo di oggetto.
-               I primi 3 sono gi definiti a zerozerouno. */
+               I primi 3 sono già definiti a zerozerouno. */
 
 double far object_elevation[203] = { 0.01, 0.01, 0.01 };
 double far object_collyblockshifting[203];
 
 // Supporti vari.
 
-short int  pix = 0; // Pixel pi vicino (ecoscandaglio, attracco automatico...)
+PixelId pix = 0; // Pixel più vicino (ecoscandaglio, attracco automatico...)
 
-char extra = 0; // Flag: attivit extraveicolare in corso?
+u8 extra = 0; // Flag: attività extraveicolare in corso?
 
 double r_x, r_y, r_z; // Posizioni relat. al pixel, per il fotogr. precedente.
 double dsx, dsy, dsz; // Posizioni reali del docksite del pixel-bersaglio.
@@ -245,7 +246,11 @@ double k1; // Costanti ausiliarie.
 int a, b, c; // Contatori ausiliari.
 
 int id; // 0, 1, 2 o 3. A seconda della distanza del pixel.
-int nopix; // Nr. Pixel.
+/// A general purpose variable, usually for keeping a Pixel ID.
+/// 
+/// This variable may be used by some functions to know which pixel
+/// is to be considered.
+int  nopix;
 
 //double ob = 15000, micro_x = 0, micro_y = 0;
 
@@ -255,14 +260,14 @@ char fermo_li = 0;
 
 int vicini = 0;
 int sta_suonando = -1;
-int pixel_sonante = -1;
+PixelId pixel_sonante = -1;
 
 FILE* recfile = nullptr;
 
 double cox = 0, coy = 0, coz = 0;
-char justloaded = 5;
+u8 justloaded = 5;
 
-char moving_last_object = 0; // Sta spostando l'ultimo oggetto lasciato.
+u8 moving_last_object = 0; // Sta spostando l'ultimo oggetto lasciato.
 double cfx, cfy, cfz; // Carried-Final-relative-X/Y/Z (dove deve andare /\).
 
 const char *source_name[] = { "SORG. PREIMPOSTATA", "C.D.", "MIC", "LINEA D'INGRESSO" };

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -31,7 +31,7 @@
 
 using namespace std;
 
-std::array<unsigned char,2> ctrlkeys = {{0,0}};
+std::array<u8, 2> ctrlkeys = {{0,0}};
 
 const char* loaded_background = nullptr;
 
@@ -267,8 +267,7 @@ void leggi_t_fino_a (FILE* fh, char codcar, int ptyp)
     t[79] = '\0';
 }
 
-void load_pixels_def(int& ptyp)
-{
+void load_pixels_def(void) {
     FILE* fh = std::fopen ("PIXELS.DEF", "rb");
     if (fh) {
         if (!trova_id (fh, "SEED")) {
@@ -292,6 +291,7 @@ void load_pixels_def(int& ptyp)
         eol = 0; leggi_t_fino_a (fh, ';', -1);
         strcpy (autore_forme, t);
         std::fseek (fh, 0, SEEK_SET);
+        int ptyp = 0;
         sprintf (t, "TYPE %d;\r\n", ptyp);
         while (trova_id (fh, t)) {
             existent_pixeltypes++;
@@ -330,7 +330,7 @@ void load_pixels_def(int& ptyp)
 
 // Carica il tipo di pixel specificato.
 
-void LoadPtyp (int ptyp) {
+void LoadPtyp (PixelTypeId ptyp) {
     int c;
     unsigned int jjj;
 
@@ -343,8 +343,8 @@ void LoadPtyp (int ptyp) {
         exit (255);
     }
 
-    pixeltype_elements[static_cast<int>(loaded_pixeltypes)] = 0;
-    pixeltype_type[static_cast<int>(loaded_pixeltypes)] = ptyp;
+    pixeltype_elements[loaded_pixeltypes] = 0;
+    pixeltype_type[loaded_pixeltypes] = ptyp;
     pixelmass[ptyp] = 10000;
 
     FILE* fh = std::fopen("PIXELS.DEF", "rb");
@@ -356,16 +356,16 @@ void LoadPtyp (int ptyp) {
         trova_id (fh, t);
         do {
             eol = 0;
-            jjj = ELEMS * loaded_pixeltypes + pixeltype_elements[static_cast<int>(loaded_pixeltypes)];
+            jjj = ELEMS * loaded_pixeltypes + pixeltype_elements[loaded_pixeltypes];
             leggi_t_fino_a (fh, ',', ptyp);
             pixel_elem_t[jjj] = 0;
-            while (pixel_elem_t[jjj]<coms && strcasecmp(t, comspec[pixel_elem_t[jjj]]))
+            while (pixel_elem_t[jjj]<COMS && strcasecmp(t, comspec[pixel_elem_t[jjj]]))
                 (pixel_elem_t[jjj])++;
-            if (pixel_elem_t[jjj] == coms) {
+            if (pixel_elem_t[jjj] == COMS) {
                 std::fclose (fh);
                 //alfin (0);
                 cerr << "Command not recognized.\nElement "
-                    << (pixeltype_elements[static_cast<int>(loaded_pixeltypes)]+1)
+                    << (pixeltype_elements[loaded_pixeltypes]+1)
                     << " in model nr. " << ptyp << "." << endl;
                 //printf ("Comando specificato nel file: %s.", t);
                 exit (1);
@@ -411,11 +411,11 @@ void LoadPtyp (int ptyp) {
                 }
             }
 //count_:
-            pixeltype_elements[static_cast<int>(loaded_pixeltypes)]++;
+            pixeltype_elements[loaded_pixeltypes]++;
 //pros:
-        } while (pixeltype_elements[static_cast<int>(loaded_pixeltypes)] < ELEMS);
+        } while (pixeltype_elements[loaded_pixeltypes] < ELEMS);
         std::fclose (fh);
-        if (pixeltype_elements[static_cast<int>(loaded_pixeltypes)]==ELEMS) {
+        if (pixeltype_elements[loaded_pixeltypes]==ELEMS) {
             //alfin (0);
             cerr << "Definition too long.\nModel nr. " << ptyp << endl;
             exit (1); // FIXME exit bomb
@@ -434,7 +434,7 @@ void load_game (char i)
 
     FILE* fh = std::fopen(t, "rb");
     if (fh) {
-        short tmp_pixels = 0;
+        u16 tmp_pixels = 0;
         std::fread (&tmp_pixels, sizeof(tmp_pixels), 1, fh);
         if (tmp_pixels == 0) {
             cerr << "Failed to read game from \"" << t << "\": Invalid situation file." << endl;
@@ -442,60 +442,60 @@ void load_game (char i)
             return;
         }
         pixels = tmp_pixels;
-        std::fread (&pixel_support[0], sizeof(double), pixels, fh);
-        std::fread (&pixel_xdisloc[0], sizeof(double), pixels, fh);
-        std::fread (&pixel_ydisloc[0], sizeof(double), pixels, fh);
-        std::fread (&pixel_zdisloc[0], sizeof(double), pixels, fh);
-        std::fread (&objects, sizeof(short), 1, fh);
+        std::fread (&pixel_support[0], sizeof(f64), pixels, fh);
+        std::fread (&pixel_xdisloc[0], sizeof(f64), pixels, fh);
+        std::fread (&pixel_ydisloc[0], sizeof(f64), pixels, fh);
+        std::fread (&pixel_zdisloc[0], sizeof(f64), pixels, fh);
+        std::fread (&objects, sizeof(u16), 1, fh);
         _objects = objects;
-        std::fread (&objecttype[0], sizeof(short), objects, fh);
-        std::fread (&relative_x[0], sizeof(double), objects, fh);
-        std::fread (&relative_y[0], sizeof(double), objects, fh);
-        std::fread (&relative_z[0], sizeof(double), objects, fh);
-        std::fread (&absolute_x[0], sizeof(double), objects, fh);
-        std::fread (&absolute_y[0], sizeof(double), objects, fh);
-        std::fread (&absolute_z[0], sizeof(double), objects, fh);
-        std::fread (&object_location[0], sizeof(short), objects, fh);
-        std::fread (&cam_x, sizeof(double), 1, fh);
-        std::fread (&cam_y, sizeof(double), 1, fh);
-        std::fread (&cam_z, sizeof(double), 1, fh);
-        std::fread (&alfa, sizeof(short), 1, fh);
-        std::fread (&beta, sizeof(short), 1, fh);
-        std::fread (&nav_a, sizeof(short), 1, fh);
-        std::fread (&nav_b, sizeof(short), 1, fh);
+        std::fread (&objecttype[0], sizeof(ObjectTypeId), objects, fh);
+        std::fread (&relative_x[0], sizeof(f64), objects, fh);
+        std::fread (&relative_y[0], sizeof(f64), objects, fh);
+        std::fread (&relative_z[0], sizeof(f64), objects, fh);
+        std::fread (&absolute_x[0], sizeof(f64), objects, fh);
+        std::fread (&absolute_y[0], sizeof(f64), objects, fh);
+        std::fread (&absolute_z[0], sizeof(f64), objects, fh);
+        std::fread (&object_location[0], sizeof(PixelId), objects, fh);
+        std::fread (&cam_x, sizeof(f64), 1, fh);
+        std::fread (&cam_y, sizeof(f64), 1, fh);
+        std::fread (&cam_z, sizeof(f64), 1, fh);
+        std::fread (&alfa, sizeof(i16), 1, fh);
+        std::fread (&beta, sizeof(i16), 1, fh);
+        std::fread (&nav_a, sizeof(i16), 1, fh);
+        std::fread (&nav_b, sizeof(i16), 1, fh);
         std::fread (&taking, 1, 1, fh);
-        std::fread (&carry_type, sizeof(short),1 ,fh);
-        std::fread (&trackframe, sizeof(double), 1, fh);
+        std::fread (&carry_type, sizeof(ObjectId),1 ,fh);
+        std::fread (&trackframe, sizeof(f64), 1, fh);
         std::fread (&reset_trackframe, 1, 1, fh);
-        std::fread (&tracking, sizeof(double), 1, fh);
+        std::fread (&tracking, sizeof(f64), 1, fh);
         std::fread (&req_end_extra, 1, 1, fh);
-        std::fread (&alfad, sizeof(short), 1, fh);
-        std::fread (&betad, sizeof(short), 1, fh);
-        std::fread (&pix, sizeof(short), 1, fh);
-        std::fread (&alfa90, sizeof(short), 1, fh);
-        std::fread (&beta90, sizeof(short), 1, fh);
+        std::fread (&alfad, sizeof(i16), 1, fh);
+        std::fread (&betad, sizeof(i16), 1, fh);
+        std::fread (&pix, sizeof(i16), 1, fh);
+        std::fread (&alfa90, sizeof(i16), 1, fh);
+        std::fread (&beta90, sizeof(i16), 1, fh);
         std::fread (&fid, 1, 1, fh);
         std::fread (&lead, 1, 1, fh);
         std::fread (&orig, 1, 1, fh);
         std::fread (&comera_m, 1, 1, fh);
-        std::fread (&spd_x, sizeof(double), 1, fh);
-        std::fread (&spd_y, sizeof(double), 1, fh);
-        std::fread (&spd_z, sizeof(double), 1, fh);
-        std::fread (&spd, sizeof(double), 1, fh);
+        std::fread (&spd_x, sizeof(f64), 1, fh);
+        std::fread (&spd_y, sizeof(f64), 1, fh);
+        std::fread (&spd_z, sizeof(f64), 1, fh);
+        std::fread (&spd, sizeof(f64), 1, fh);
         std::fread (&extra, 1, 1, fh);
-        std::fread (&rel_x, sizeof(double), 1, fh);
-        std::fread (&rel_y, sizeof(double), 1, fh);
-        std::fread (&rel_z, sizeof(double), 1, fh);
-        std::fread (&obj, sizeof(short), 1, fh);
+        std::fread (&rel_x, sizeof(f64), 1, fh);
+        std::fread (&rel_y, sizeof(f64), 1, fh);
+        std::fread (&rel_z, sizeof(f64), 1, fh);
+        std::fread (&obj, sizeof(ObjectId), 1, fh);
         std::fread (&m, 1, 1, fh);
         std::fread (&echo, 1, 1, fh);
-        std::fread (&carried_pixel, sizeof(short), 1, fh);
-        std::fread (&disl, sizeof(double), 1, fh);
-        std::fread (&cursore, sizeof(short), 1, fh);
-        std::fread (&explode_count, 1, 1, fh);
+        std::fread (&carried_pixel, sizeof(carried_pixel), 1, fh);
+        std::fread (&disl, sizeof(disl), 1, fh);
+        std::fread (&cursore, sizeof(cursore), 1, fh);
+        std::fread (&explode_count, sizeof(explode_count), 1, fh);
         std::fread (&ctrlkeys[0], 1, 1, fh);
         std::fread (&pixel_rot[0], 1, pixels, fh);
-        std::fread (&pixeltype[0], sizeof(short), pixels, fh);
+        std::fread (&pixeltype[0], sizeof(PixelTypeId), pixels, fh);
         std::fread (&repeat, 1, 1, fh);
         std::fread (&source, 1, 1, fh);
         std::fread (&quality, 1, 1, fh);
@@ -519,63 +519,65 @@ void save_game (char i)
     sprintf (t, "CRYXTELS.%cIT", i);
     FILE* fh = std::fopen (t, "wb");
     if (fh) {
-        unsigned char a;
 
-        std::fwrite (&pixels, sizeof(short), 1, fh);
-        std::fwrite (&pixel_support[0], sizeof(double), pixels, fh);
-        std::fwrite (&pixel_xdisloc[0], sizeof(double), pixels, fh);
-        std::fwrite (&pixel_ydisloc[0], sizeof(double), pixels, fh);
-        std::fwrite (&pixel_zdisloc[0], sizeof(double), pixels, fh);
-        std::fwrite (&objects, sizeof(short), 1, fh);
-        std::fwrite (&objecttype[0], sizeof(short), objects, fh);
-        std::fwrite (&relative_x[0], sizeof(double), objects, fh);
-        std::fwrite (&relative_y[0], sizeof(double), objects, fh);
-        std::fwrite (&relative_z[0], sizeof(double), objects, fh);
-        std::fwrite (&absolute_x[0], sizeof(double), objects, fh);
-        std::fwrite (&absolute_y[0], sizeof(double), objects, fh);
-        std::fwrite (&absolute_z[0], sizeof(double), objects, fh);
-        std::fwrite (&object_location[0], sizeof(short int), objects, fh);
-        std::fwrite (&cam_x, sizeof(double), 1, fh);
-        std::fwrite (&cam_y, sizeof(double), 1, fh);
-        std::fwrite (&cam_z, sizeof(double), 1, fh);
-        std::fwrite (&alfa, sizeof(short), 1, fh);
-        std::fwrite (&beta, sizeof(short), 1, fh);
-        std::fwrite (&nav_a, sizeof(short), 1, fh);
-        std::fwrite (&nav_b, sizeof(short), 1, fh);
-        std::fwrite (&taking, sizeof(char), 1, fh);
-        std::fwrite (&carry_type, sizeof(short), 1, fh);
-        std::fwrite (&trackframe, sizeof(double), 1, fh);
-        std::fwrite (&reset_trackframe, sizeof(char), 1, fh);
-        std::fwrite (&tracking, sizeof(double), 1, fh);
-        std::fwrite (&req_end_extra, sizeof(char), 1, fh);
-        std::fwrite (&alfad, sizeof(short), 1, fh);
-        std::fwrite (&betad, sizeof(short), 1, fh);
-        std::fwrite (&pix, sizeof(short), 1, fh);
-        std::fwrite (&alfa90, sizeof(short), 1, fh);
-        std::fwrite (&beta90, sizeof(short), 1, fh);
+        std::fwrite (&pixels, sizeof(u16), 1, fh);
+        std::fwrite (&pixel_support[0], sizeof(f64), pixels, fh);
+        std::fwrite (&pixel_xdisloc[0], sizeof(f64), pixels, fh);
+        std::fwrite (&pixel_ydisloc[0], sizeof(f64), pixels, fh);
+        std::fwrite (&pixel_zdisloc[0], sizeof(f64), pixels, fh);
+        std::fwrite (&objects, sizeof(i16), 1, fh);
+        std::fwrite (&objecttype[0], sizeof(i16), objects, fh);
+        std::fwrite (&relative_x[0], sizeof(f64), objects, fh);
+        std::fwrite (&relative_y[0], sizeof(f64), objects, fh);
+        std::fwrite (&relative_z[0], sizeof(f64), objects, fh);
+        std::fwrite (&absolute_x[0], sizeof(f64), objects, fh);
+        std::fwrite (&absolute_y[0], sizeof(f64), objects, fh);
+        std::fwrite (&absolute_z[0], sizeof(f64), objects, fh);
+        std::fwrite (&object_location[0], sizeof(i16), objects, fh);
+        std::fwrite (&cam_x, sizeof(f64), 1, fh);
+        std::fwrite (&cam_y, sizeof(f64), 1, fh);
+        std::fwrite (&cam_z, sizeof(f64), 1, fh);
+        std::fwrite (&alfa, sizeof(i16), 1, fh);
+        std::fwrite (&beta, sizeof(i16), 1, fh);
+        std::fwrite (&nav_a, sizeof(i16), 1, fh);
+        std::fwrite (&nav_b, sizeof(i16), 1, fh);
+        std::fwrite (&taking, sizeof(u8), 1, fh);
+        std::fwrite (&carry_type, sizeof(ObjectId), 1, fh);
+        std::fwrite (&trackframe, sizeof(f64), 1, fh);
+        std::fwrite (&reset_trackframe, sizeof(u8), 1, fh);
+        std::fwrite (&tracking, sizeof(f64), 1, fh);
+        std::fwrite (&req_end_extra, sizeof(u8), 1, fh);
+        std::fwrite (&alfad, sizeof(i16), 1, fh);
+        std::fwrite (&betad, sizeof(i16), 1, fh);
+        std::fwrite (&pix, sizeof(PixelId), 1, fh);
+        std::fwrite (&alfa90, sizeof(i16), 1, fh);
+        std::fwrite (&beta90, sizeof(i16), 1, fh);
         std::fwrite (&fid, 1, 1, fh);
         std::fwrite (&lead, 1, 1, fh);
         std::fwrite (&orig, 1, 1, fh);
         std::fwrite (&comera_m, 1, 1, fh);
-        std::fwrite (&spd_x, sizeof(double), 1, fh);
-        std::fwrite (&spd_y, sizeof(double), 1, fh);
-        std::fwrite (&spd_z, sizeof(double), 1, fh);
-        std::fwrite (&spd, sizeof(double), 1, fh);
+        std::fwrite (&spd_x, sizeof(f64), 1, fh);
+        std::fwrite (&spd_y, sizeof(f64), 1, fh);
+        std::fwrite (&spd_z, sizeof(f64), 1, fh);
+        std::fwrite (&spd, sizeof(f64), 1, fh);
         std::fwrite (&extra, 1, 1, fh);
-        std::fwrite (&rel_x, sizeof(double), 1, fh);
-        std::fwrite (&rel_y, sizeof(double), 1, fh);
-        std::fwrite (&rel_z, sizeof(double), 1, fh);
-        std::fwrite (&obj, sizeof(short), 1, fh);
+        std::fwrite (&rel_x, sizeof(f64), 1, fh);
+        std::fwrite (&rel_y, sizeof(f64), 1, fh);
+        std::fwrite (&rel_z, sizeof(f64), 1, fh);
+        std::fwrite (&obj, sizeof(ObjectId), 1, fh);
         std::fwrite (&m, 1, 1, fh);
         std::fwrite (&echo, 1, 1, fh);
-        std::fwrite (&carried_pixel, sizeof(short), 1, fh);
-        std::fwrite (&disl, sizeof(double), 1, fh);
-        std::fwrite (&cursore, sizeof(short), 1, fh);
+        std::fwrite (&carried_pixel, sizeof(PixelId), 1, fh);
+        std::fwrite (&disl, sizeof(f64), 1, fh);
+        std::fwrite (&cursore, sizeof(u16), 1, fh);
         std::fwrite (&explode_count, 1, 1, fh);
-        a = ctrlkeys[0]; if (a&2) a ^= 2;
-        std::fwrite (&a, 1, 1, fh);
+
+        // drop left shift flag,
+        // otherwise it could try to save immediately on load
+        u8 crtkey_0 = ctrlkeys[0] & (~2u);
+        std::fwrite (&crtkey_0, 1, 1, fh);
         std::fwrite (&pixel_rot[0], 1, pixels, fh);
-        std::fwrite (&pixeltype[0], sizeof(short), pixels, fh);
+        std::fwrite (&pixeltype[0], sizeof(PixelTypeId), pixels, fh);
         std::fwrite (&repeat, 1, 1, fh);
         std::fwrite (&source, 1, 1, fh);
         auto conta = std::fwrite (&quality, 1, 1, fh);


### PR DESCRIPTION
This is a major refactor to replace most uses of integral types such as `int` and `short` to use fixed width types. This should make the code clearer and more resilient.