### PR TITLE
Discard relative mouse movement from introduction screen

### DIFF
--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -377,6 +377,9 @@ int main(int argc, char** argv)
         SDL_SetRelativeMouseMode(SDL_TRUE);
     }
 
+    // discard relativa mouse movements up to now
+    SDL_GetRelativeMouseState(&mdltx, &mdlty);
+
     // Ciclo principale.
     bool quit_now = false;
 	do


### PR DESCRIPTION
This prevents The Fly or the player from looking at an orientation which differs from the one intended just because the mouse was moved while in the introduction screen.