### PR TITLE
Reorganized & Fixed some graphics routines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ Makefile
 /cryxtels
 /cryxtels.exe
 /bin/cryxtels
-/bin/cryxtels.exe
+/bin/cryxtels*.exe
 /bin/CRYXTELS.*IT
 /bin/SNAP*.bmp
 /bin/TEXT-*.FIX
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,5 @@ include_directories(include ${SDL2_INCLUDE_DIR})
 
 # add the executable
 add_executable(cryxtels
-    source/cryxtels.cpp source/fast3d.cpp source/global.cpp source/input.cpp source/text3d.cpp)
+    source/cryxtels.cpp source/fast3d.cpp source/global.cpp source/input.cpp source/text3d.cpp source/draw.cpp)
 target_link_libraries(cryxtels ${SDL2_LIBRARY} ${SDL2MAIN_LIBRARY})

--- a/include/draw.h
+++ b/include/draw.h
@@ -1,0 +1,82 @@
+/** \file draw.h
+ *  This file is part of Crystal Pixels.
+ *
+ *  Crystal Pixels is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Crystal Pixels is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Draw header file
+// it contains functions that draw common shapes, UI elements, etc
+#ifndef DRAW_H_INCLUDED
+#define DRAW_H_INCLUDED
+
+#include "primitives.h"
+
+/// Draw a line relative to the position of the ship
+void draw_line_relative (double sx, double sy, double sz, double fx, double fy, double fz);
+
+/// Draw text relative to the position of the ship
+void draw_text_relative (const char *testo, double x, double y, double z, double sx, double sy);
+
+/// Draw rectangle relative to the position of the ship
+void draw_rect_relative (double x, double y, double z, double l, double h);
+
+// Draw a console key on the ship's console.
+void draw_console_key (const char *serigraph, double x, char cod, char input, char current_state, char previous_state);
+
+
+
+/* HUD indicators: */
+
+// main crosshair in the middle of the HUD
+void draw_indicator_crosshair();
+
+// "X" crosshair in the direction of motion
+void draw_indicator_prograde(int x, int y);
+
+// "#" crosshair in the direction opposite to that of motion
+void draw_indicator_retrograde(int x, int y);
+
+// "+" crosshair on the closest pixel
+void draw_indicator_closest(int x, int y);
+
+
+
+/* ship geometry: */
+
+// strictly necessary cockpit elements
+void draw_vehicle_interior();
+
+// the fly as seen from the outside
+void draw_vehicle_exterior();
+
+// attitude indicators are part of the vehicle
+void draw_vehicle_attitude(i16 alpha, i16 beta, char blink);
+
+
+
+/* info panel readings: */
+
+void draw_readings_force(double force);
+
+void draw_readings_speed(double speed);
+
+void draw_readings_docked();
+
+void draw_readings_heading(i16 alpha, i16 beta);
+
+void draw_readings_position(double x, double y, double z);
+
+void draw_readings_closest(double distance);
+
+#endif

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -23,10 +23,6 @@
 #include <memory>
 #include "primitives.h"
 
-#ifndef far
-#define far
-#endif
-
 constexpr double Pi = 3.141592653589793238462643383;
 
 /// The software membory buffer to perform all rendering in.
@@ -36,9 +32,9 @@ extern std::unique_ptr<u8[]> video_buffer;
 //extern SDL_Surface * p_surface_scaled;
 
 /// Some old adapters.
-//unsigned char far * adaptor = (unsigned char far *) 0xA0000000;
-//unsigned char far * adapted = (unsigned char far *) 0x80000000;
-//unsigned char far * fake_adaptor = (unsigned char far *) 0x80000000;
+//unsigned char * adaptor = (unsigned char *) 0xA0000000;
+//unsigned char * adapted = (unsigned char *) 0x80000000;
+//unsigned char * fake_adaptor = (unsigned char *) 0x80000000;
 
 /// This is the main palette.
 //extern unsigned char tmppal[768];
@@ -95,7 +91,7 @@ void pcopy (u8 *dest, const u8 *sorg);
 
 /// Clear a graphical page with a pattern
 // Ultraveloce cancella pagina grafica.
-void pclear (u8 far *target, u8 pattern);
+void pclear (u8 *target, u8 pattern);
 
 /// Initialization of a table of trigonometric calculation results.
 // Inizializzazione.

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -68,9 +68,6 @@ void init_video ();
 /// (new) Toggle fullscreen mode
 void toggle_fullscreen();
 
-/// Do nothing here, it's no longer needed
-inline void _80_25_C () {} // modo grafico 80x25 testo a colori.
-
 /// Darken the screen once.
 void darken_once(u8 inc = 1);
 
@@ -115,7 +112,8 @@ extern char explode;
 void Line3D (double p_x, double p_y, double p_z,
 	     double x, double y, double z);
 
-// Conversioni x, y, z -> share_x, share_y
+// Compute whether a point is visible from the camera.
+// If it is, set share_x and share_y to its coordinates on-screen
 extern int share_x;
 extern int share_y;
 int C32 (double x, double y, double z);

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -48,7 +48,7 @@ extern float *tcosy, *tsiny;
 extern double cam_x, cam_y, cam_z;
 
 /// Alpha and Beta (camera orientation)
-extern i16 alfa,beta;
+extern i16 alpha,beta;
 
 /// Distance to the closest pixel.
 extern double kk;

--- a/include/global.h
+++ b/include/global.h
@@ -89,8 +89,8 @@ extern double tracking; // Increment value to trackframe.
 /// Counter for the number of frames of the Fly reentering sequence.
 extern u8 req_end_extra;
 
-extern i16 alfad, betad; // Angular speed of x and y.
-extern i16 alfa90, beta90; // Support for some calculations.
+extern i16 v_alpha, v_beta; // Angular speed of x and y.
+extern i16 alpha90, beta90; // Support for some calculations.
 
 extern u8 fid; // Flag: Orientation of the direction opposite to the current one...
 extern u8 lead; // Flag: Orientation of the leading direction...
@@ -239,9 +239,7 @@ extern double *absolute_y;      // Position Y (absolute for Pixel = -1).
 extern double *absolute_z;      // Position Z (absolute for Pixel = -1).
 extern PixelId  *object_location; // Pixel where the object can be retrieved.
 
-/* IMPORTANT: the object's elevation at the pixel's surface for each object type.
- */
-
+// The object's elevation at the pixel's surface for each object type.
 extern double object_elevation[203];
 extern double object_collyblockshifting[203];
 

--- a/include/global.h
+++ b/include/global.h
@@ -264,7 +264,7 @@ extern double nav_y;
 extern double nav_z;
 
 extern double d; // Distanza generica.
-extern double k1; // Costanti ausiliarie.
+extern double k0, k1; // Costanti ausiliarie.
 extern int a, b, c; // Contatori ausiliari.
 
 extern int id; // 0, 1, 2 o 3. A seconda della distanza del pixel.

--- a/include/global.h
+++ b/include/global.h
@@ -18,11 +18,6 @@
 #ifndef GLOBAL_H_INCLUDED
 #define GLOBAL_H_INCLUDED
 
-// Discarding all old "far" qualifiers
-#ifndef far
-#define far
-#endif
-
 // provide strcasecmp to msvc
 #ifdef _MSC_VER
 #include <string.h>
@@ -150,15 +145,15 @@ extern u16 existent_objecttypes;
 
 extern u16 pixels; // Total nr. of pixels (not initialized).
 
-extern PixelTypeId far *pixeltype; // Pixel type array, from 0 to existent_pixeltypes-1.
+extern PixelTypeId *pixeltype; // Pixel type array, from 0 to existent_pixeltypes-1.
 
-extern u8 far *pixel_rot; // Rotation amount around Sunny flag.
+extern u8 *pixel_rot; // Rotation amount around Sunny flag.
 
-extern float far  *pixel_absd;    // Absolute distance from the observer.
-extern double far *pixel_support; // Support for which pixel (in memory).
-extern double far *pixel_xdisloc; // Position X.
-extern double far *pixel_ydisloc; //     -    Y.
-extern double far *pixel_zdisloc; //     -    Z.
+extern float  *pixel_absd;    // Absolute distance from the observer.
+extern double *pixel_support; // Support for which pixel (in memory).
+extern double *pixel_xdisloc; // Position X.
+extern double *pixel_ydisloc; //     -    Y.
+extern double *pixel_zdisloc; //     -    Z.
 
 // Command definitions.
 
@@ -193,15 +188,15 @@ extern const char *comspec[COMS];
 
 extern const u8 params[COMS];
 
-extern u8 far *pixel_elem_t;   // Element types. size = ELEMS*BUFFERS
+extern u8 *pixel_elem_t;   // Element types. size = ELEMS*BUFFERS
 
-extern double far *pixel_elem_x; // Coordinates relative to pixel.
-extern double far *pixel_elem_y;
-extern double far *pixel_elem_z;
-extern float  far *pixel_elem_1; // Special parameters (l, h, p, r, orient) ...
-extern float  far *pixel_elem_2;
-extern float  far *pixel_elem_3;
-extern float  far *pixel_elem_4;
+extern double *pixel_elem_x; // Coordinates relative to pixel.
+extern double *pixel_elem_y;
+extern double *pixel_elem_z;
+extern float  *pixel_elem_1; // Special parameters (l, h, p, r, orient) ...
+extern float  *pixel_elem_2;
+extern float  *pixel_elem_3;
+extern float  *pixel_elem_4;
 
 /** Text buffer for the TEXT function (40 car.),
  * the buffer contains the text, but can contain the
@@ -209,26 +204,26 @@ extern float  far *pixel_elem_4;
  * Text parameters, in numeric order from 0:
  * x, y, z, scalax, scalay, or.x, or.y
  */
-extern char far *pixel_elem_b;
+extern char *pixel_elem_b;
 
 // Position of the docking type for each pixel type.
 
 /// X coordinate of each pixel's dock site
-extern float far *docksite_x;
+extern float *docksite_x;
 /// Y coordinate of each pixel's dock site
-extern float far *docksite_y;
+extern float *docksite_y;
 /// Z coordinate of each pixel's dock site
-extern float far *docksite_z;
+extern float *docksite_z;
 /// Dock site width for each pixel.
-extern float far *docksite_w;
+extern float *docksite_w;
 /// Dock site height for each pixel.
-extern float far *docksite_h;
+extern float *docksite_h;
 
 // Pixel mass
-extern float far *pixelmass;
+extern float *pixelmass;
 
 // Files for sottofondi audio.
-extern char far *subsignal;
+extern char *subsignal;
 
 /* Concerning objects. */
 
@@ -236,12 +231,12 @@ extern u16 objects; // Total nr. of objects (not initialized).
 extern u16 _objects; // Variable used when cycling for the total number of objects.
 
 extern ObjectTypeId  *objecttype;      // Object type.
-extern double far *relative_x;      // Position X (relative to pixel).
-extern double far *relative_y;      // Position Y (relative to pixel).
-extern double far *relative_z;      // Position Z (relative to pixel).
-extern double far *absolute_x;      // Position X (absolute for Pixel = -1).
-extern double far *absolute_y;      // Position Y (absolute for Pixel = -1).
-extern double far *absolute_z;      // Position Z (absolute for Pixel = -1).
+extern double *relative_x;      // Position X (relative to pixel).
+extern double *relative_y;      // Position Y (relative to pixel).
+extern double *relative_z;      // Position Z (relative to pixel).
+extern double *absolute_x;      // Position X (absolute for Pixel = -1).
+extern double *absolute_y;      // Position Y (absolute for Pixel = -1).
+extern double *absolute_z;      // Position Z (absolute for Pixel = -1).
 extern PixelId  *object_location; // Pixel where the object can be retrieved.
 
 /* IMPORTANT: the object's elevation at the pixel's surface for each object type.

--- a/include/global.h
+++ b/include/global.h
@@ -251,7 +251,7 @@ extern double object_collyblockshifting[203];
 extern PixelId pix;
 
 /// Flag: 1 = extravehicular activity (walking on a pixel); 0 = on Fly
-extern u8 extra;
+extern u8 EVA_in_progress;
 
 extern double r_x, r_y, r_z; // Posizioni relat. al pixel, per il fotogr. precedente.
 extern double dsx, dsy, dsz; // Posizioni reali del docksite del pixel-bersaglio.

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -164,7 +164,7 @@ void extra_stop_extra ();
 
 /// Look for angles starting from coordinates relative to the observer. (alpha & beta)
 // Per cercare angoli partendo da coordinate relative all'osservatore.
-void find_alfabeta();
+void find_alphabeta();
 
 /// Invert direction
 void fid_on ();
@@ -281,8 +281,8 @@ int main(int argc, char** argv)
  * false to end the introduction
  */
 bool intro_loop() {
-    static const int FOTTY_VIEWPORT_LOWER = HEIGHT*65/200;
-    static const int FOTTY_VIEWPORT_UPPER = HEIGHT*135/200;
+    static const int FOTTY_VIEWPORT_UPPER = HEIGHT*65/200;
+    static const int FOTTY_VIEWPORT_LOWER = HEIGHT*135/200;
 
     //if (!sbp_stat) play (0);
     u32 sync = SDL_GetTicks(); //clock();
@@ -326,21 +326,21 @@ bool intro_loop() {
         cam_y -= 140;
         beta = tmp;
 
-        u16 current_frame = (SDL_GetTicks()/INTRO_TICKS_PER_FRAME) % WIDTH;
+        u16 time = (SDL_GetTicks()/INTRO_TICKS_PER_FRAME) & 0xFFFF; // WIDTH;
         u32 cx = WIDTH*50;
         do {
-            if (current_frame < WIDTH*HEIGHT) {
+            if (time < WIDTH*HEIGHT) {
                 // pixel value outside fottifoh row range
-                if (current_frame < WIDTH*FOTTY_VIEWPORT_LOWER + 4 ||
-                    current_frame >= WIDTH*FOTTY_VIEWPORT_UPPER + 4)
+                if (time < WIDTH*FOTTY_VIEWPORT_UPPER + 4 ||
+                    time >= WIDTH*FOTTY_VIEWPORT_LOWER + 4)
                 {
-                    video_buffer[current_frame] >>= 1;
+                    video_buffer[time] >>= 1;
                 }
             }
             if (cx >= WIDTH*50/2) {
-                current_frame += WIDTH + 1;
+                time +=  WIDTH + 1;
             } else {
-                current_frame += WIDTH - 1;
+                time += WIDTH - 1;
             }
         } while (--cx > 0);
 
@@ -1914,7 +1914,7 @@ void extra_stop_extra ()
     }
 }
 
-void find_alfabeta()
+void find_alphabeta()
 {
     kk = 1E9;
     for (c=0; c<360; c++) {
@@ -1952,7 +1952,7 @@ void fid_on ()
         rx = cam_x + 100 * tsin[beta] * tcos[alpha];
         rz = cam_z - 100 * tcos[beta] * tcos[alpha];
         ry = cam_y - 100 * tsin[alpha];
-        find_alfabeta ();
+        find_alphabeta ();
         fid = 1;
 }
 
@@ -1962,7 +1962,7 @@ void lead_on ()
     rx = cam_x + spd_x;
     ry = cam_y + spd_y;
     rz = cam_z + spd_z;
-    find_alfabeta ();
+    find_alphabeta ();
     lead = 1;
 }
 
@@ -1972,7 +1972,7 @@ void orig_on ()
     rx = cam_x / 1.001;
     ry = cam_y / 1.001;
     rz = cam_z / 1.001;
-    find_alfabeta ();
+    find_alphabeta ();
     orig = 1;
 }
 

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -43,10 +43,6 @@
 #include "SDL.h"
 #include "conf.h"
 
-#ifndef far
-#define far
-#endif
-
 using namespace std;
 
 constexpr int TICKS_IN_A_SECOND = 1000;

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -2680,7 +2680,7 @@ ogg_2:
                                     _z = p2 - p3*180 + p6*p3;
                                     _ox = p0; _oz = _z - p6*p3;
                                     for (c=p6; c<=360; c+=p6) {
-                                        _x = tsin[c] * p4;
+                                        _x = p0 + tsin[c] * p4;
                                         rel (_x, p1, _z, _ox, p1, _oz);
                                         _ox = _x;
                                         _oz = _z;

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -38,6 +38,7 @@
 #include "fast3d.h"
 #include "text3d.h"
 #include "input.h"
+#include "draw.h"
 #include "sdl_exception.h"
 
 #include "SDL.h"
@@ -146,19 +147,6 @@ void Oggetti_sul_Pixel (char oblige); // not implemented
 /// Function that leaves the taken object on the ground.
 void lascia_cadere ();
 
-/// Draw a console key on The Fly's console.
-void console_key (const char *serigraph, double x, char cod, char input, char cond_attu, char cond_prec);
-
-// Traccia una linea relativamente alla posizione della nave.
-/// Draw a line relative to the position of the ship
-void n (double sx, double sy, double sz, double fx, double fy, double fz);
-
-/// Draw text relative to the position of the ship
-void nTxt (const char *testo, double x, double y, double z, double sx, double sy);
-
-/// Draw rectangle relative to the position of the ship
-void nrect (double x, double y, double z, double l, double h);
-
 /// Thrust / Walk Forward
 void ispd ();
 
@@ -174,7 +162,7 @@ void undock ();
 /// Enter/Leave The Fly
 void extra_stop_extra ();
 
-/// Look for angles starting from coordinates relative to the observer. (alfa & beta)
+/// Look for angles starting from coordinates relative to the observer. (alpha & beta)
 // Per cercare angoli partendo da coordinate relative all'osservatore.
 void find_alfabeta();
 
@@ -244,7 +232,7 @@ int main(int argc, char** argv)
     // Don't run the intro if a game is loaded by the user.
     bool run_intro = (argc!=2);
 
-    cam_y = -4680; alfa = 90;
+    cam_y = -4680; alpha = 90;
     ox = 0; oy = 0; oz = 0;
 
     sprintf (t, "%s'S MICROCOSM", autore_forme);
@@ -389,17 +377,17 @@ bool main_loop() {
             sync = clock();
         } */
         // Effetti del sistema di virata.
-        alfa+=alfad;
-        if (alfa<0) alfa+=360;
-        if (alfa>=360) alfa-=360;
+        alpha+=alfad;
+        if (alpha<0) alpha+=360;
+        if (alpha>=360) alpha-=360;
         beta+=betad;
         if (beta<0) beta+=360;
         if (beta>=360) beta-=360;
 
         // Movimento manuale.
-        spd_x -= (double)spd * 0.01 * tsin[beta] * tcos[alfa];
-        spd_z += (double)spd * 0.01 * tcos[beta] * tcos[alfa];
-        spd_y += (double)spd * 0.01 * tsin[alfa];
+        spd_x -= (double)spd * 0.01 * tsin[beta] * tcos[alpha];
+        spd_z += (double)spd * 0.01 * tcos[beta] * tcos[alpha];
+        spd_y += (double)spd * 0.01 * tsin[alpha];
 
         // Movimento inerziale.
         cam_x += spd_x;
@@ -414,7 +402,7 @@ bool main_loop() {
             dei pixels dall'osservatore. */
         dists ();
 
-        /* if (extra) {
+        /* if (EVA_in_progress) {
                 rx = pixel_xdisloc[pix] + rel_x - cam_x;
                 ry = pixel_ydisloc[pix] + rel_y - cam_y;
                 rz = pixel_zdisloc[pix] + rel_z - cam_z;
@@ -425,7 +413,7 @@ bool main_loop() {
             pix = 0;
             for (u16 p = 0; p < pixels ; p++)
                 if (pixel_absd[pix]>pixel_absd[p]) {
-                    if (carried_pixel>-1&&p==pixels-1) break;
+                    if (carried_pixel>-1 && p==pixels-1) break;
                     pix = p;
                 }
         }
@@ -447,7 +435,7 @@ bool main_loop() {
 
             bool update_angles = true;
 
-            if (!extra) {
+            if (!EVA_in_progress) {
                 if (trackframe) {
                     my = 0;
                     if (trackframe==23)
@@ -472,7 +460,7 @@ bool main_loop() {
                 while (my<0) my += 1800;
 
                 beta = mx / 5;
-                alfa = my / 5;
+                alpha = my / 5;
             }
         }
 
@@ -519,25 +507,25 @@ bool main_loop() {
                         break;
                     case keymap_up:
                         if ((ctrlkeys[0]&3) || type_mode || fermo_li || m) break;
-                        if ((trackframe!=0)&&!extra) break;
+                        if ((trackframe!=0)&&!EVA_in_progress) break;
                         alfad--;
                         if (alfad<-3) alfad=-3;
                         break;
                     case keymap_down:
                         if ((ctrlkeys[0]&3) || type_mode || fermo_li || m) break;
-                        if (trackframe&&!extra) break;
+                        if (trackframe&&!EVA_in_progress) break;
                         alfad++;
                         if (alfad>3) alfad=3;
                         break;
                     case keymap_right:
                         if ((ctrlkeys[0]&3) || type_mode || fermo_li || m) break;
-                        if (trackframe&&!extra) break;
+                        if (trackframe&&!EVA_in_progress) break;
                         betad--;
                         if (betad<-3) betad=-3;
                         break;
                     case keymap_left:
                         if ((ctrlkeys[0]&3) || type_mode || fermo_li || m) break;
-                        if (trackframe&&!extra) break;
+                        if (trackframe&&!EVA_in_progress) break;
                         betad++;
                         if (betad>3) betad=3;
                         break;
@@ -568,7 +556,7 @@ bool main_loop() {
                         snapshot (); // take a snapshot
                         break;
                     case SDLK_F7: // previously scroll lock
-                        if (!extra)
+                        if (!EVA_in_progress)
                             type_mode = false;
                         else
                             type_mode = !type_mode; // enter text typing mode
@@ -631,7 +619,7 @@ bool main_loop() {
                         alfad = 0;
                         betad = 0;
                         mx = beta * 5;
-                        my = alfa * 5;
+                        my = alpha * 5;
                         if (grab_mouse) {
                             SDL_SetRelativeMouseMode(m ? SDL_TRUE : SDL_FALSE);
 
@@ -662,7 +650,7 @@ bool main_loop() {
                     }
 
                     // Loading and saving
-                    if ((i>=SDLK_a&&i<=SDLK_z) || i == SDLK_ASTERISK) {
+                    if ((i>=SDLK_a && i<=SDLK_z) || i == SDLK_ASTERISK) {
                         if (ctrlkeys[0]&1) {
                             load_situation(i);
                         } else if (ctrlkeys[0]&2) {
@@ -692,7 +680,7 @@ bool main_loop() {
                         }
                     }
                     */
-                    if (dsol<15000&&(i>=SDLK_0&&i<=SDLK_9)) {
+                    if (dsol<15000&&(i>=SDLK_0 && i<=SDLK_9)) {
                         if (carry_type>-1)
                             carry_type = ((int)i-SDLK_0) * existent_objecttypes / 10;
                         if ((ctrlkeys[0]&64)&&carried_pixel>-1) { // caps lock && is carrying pixel
@@ -729,7 +717,7 @@ bool main_loop() {
         }
         if (mpul == 2) { // right mouse button
             dspd ();
-            if (!extra) {
+            if (!EVA_in_progress) {
                 if (rclick==-1)
                     rclick = SDL_GetTicks();
                 else {
@@ -762,7 +750,7 @@ bool main_loop() {
                 undock ();
                 i = 62;
             }
-            if (extra) {
+            if (EVA_in_progress) {
                 if (carry_type==-1)
                     taking = 1;
                 else {
@@ -803,13 +791,13 @@ bool main_loop() {
         }
 
         // Ridimensionamento angolazione verticale in "extra attivit".
-        if (extra&&alfa>90&&alfa<270) {
+        if (EVA_in_progress && alpha>90 && alpha<270) {
             alfad = 0;
-            if (alfa>180)
-                alfa = 270;
+            if (alpha>180)
+                alpha = 270;
             else
-                alfa = 90;
-            my = alfa * 5;
+                alpha = 90;
+            my = alpha * 5;
         }
 
         if (reset_trackframe) {
@@ -821,19 +809,19 @@ bool main_loop() {
         // FID (freno inerziale diamagnetico).
         // Non pi cos facile: ora c' lo SPIN.
         if (fid||lead||orig) {
-            alfad = alfa90 - alfa;
+            alfad = alfa90 - alpha;
             if (alfad>5) alfad = 5;
             if (alfad<-5) alfad = -5;
-            alfa += alfad;
+            alpha += alfad;
             betad = beta90 - beta;
             if (betad>5) betad = 5;
             if (betad<-5) betad = -5;
             beta += betad;
-            if (alfa==alfa90&&beta==beta90) {
+            if (alpha==alfa90 && beta==beta90) {
                 m = comera_m;
                 mx = beta * 5;
-                my = alfa * 5;
-                if (orig&&carried_pixel>-1) {
+                my = alpha * 5;
+                if (orig && carried_pixel>-1) {
                     carried_pixel--;
                     if (carried_pixel<0) carried_pixel = existent_pixeltypes - 1;
                     pixeltype[pixels-1] = carried_pixel;
@@ -849,7 +837,7 @@ bool main_loop() {
 
         obj = -1;
 
-        if (extra) {
+        if (EVA_in_progress) {
             if (fabs(disl)>1)
                 rel_y += disl / 3;
             else
@@ -904,15 +892,15 @@ bool main_loop() {
                     dx = 0;
                     cx = WIDTH;
                     auto si = ax % cx; // si = 1280 % WIDTH
-                    ax = alfa;
+                    ax = alpha;
                     cx = 360;
                     dx = 0;
-                    ax = ax % cx; // alfa % 360
+                    ax = ax % cx; // alpha % 360
                     dx = 3;
-                    ax = ax * dx; // (alfa % 360) * 3
+                    ax = ax * dx; // (alpha % 360) * 3
                     dx = 0;
                     cx = WIDTH;
-                    ax = ax * cx; // ax = (alfa % 360) * 3 * WIDTH
+                    ax = ax * cx; // ax = (alpha % 360) * 3 * WIDTH
                     cx = ax >> 16; // cx = ax >> 16
                     dx = ax;
                     dx += si;
@@ -962,9 +950,9 @@ bool main_loop() {
                 coz += pixel_zdisloc[pix] - prevpixz;
             }
 
-            coy += ((cam_y + 9 * tsin[alfa]) - coy) / justloaded;
-            cox += ((cam_x - 9 * tsin[beta] * tcos[alfa]) - cox) / justloaded;
-            coz += ((cam_z + 9 * tcos[beta] * tcos[alfa]) - coz) / justloaded;
+            coy += ((cam_y + 9 * tsin[alpha]) - coy) / justloaded;
+            cox += ((cam_x - 9 * tsin[beta] * tcos[alpha]) - cox) / justloaded;
+            coz += ((cam_z + 9 * tcos[beta] * tcos[alpha]) - coz) / justloaded;
             if (trackframe==23&&!memcmp(&subsignal[9*(carry_type+FRONTIER_M3)], "MAGNIFY" /*"VISORE"*/, 7/*6*/)) {
                 cam_x = cox;
                 cam_y = coy;
@@ -978,7 +966,7 @@ bool main_loop() {
 
         // Gestione pixels "donati" dal Solicchio.
         if (dsol<500)
-            if (pixels<MAX_PIXELS&&carried_pixel==-1) {
+            if (pixels<MAX_PIXELS && carried_pixel==-1) {
                 carried_pixel = existent_pixeltypes - 1;
                 pixeltype[pixels] = carried_pixel;
                 pixel_support[pixels] = 0;
@@ -987,10 +975,10 @@ bool main_loop() {
             }
 
         if (carried_pixel>-1) {
-            pixel_ydisloc[pixels-1] = cam_y + 1000 * tsin[alfa];
-            pixel_xdisloc[pixels-1] = cam_x - 1000 * tsin[beta] * tcos[alfa];
-            pixel_zdisloc[pixels-1] = cam_z + 1000 * tcos[beta] * tcos[alfa];
-            if (veloc<2&&dsol>500&&!trackframe) carried_pixel = -1;
+            pixel_ydisloc[pixels-1] = cam_y + 1000 * tsin[alpha];
+            pixel_xdisloc[pixels-1] = cam_x - 1000 * tsin[beta] * tcos[alpha];
+            pixel_zdisloc[pixels-1] = cam_z + 1000 * tcos[beta] * tcos[alpha];
+            if (veloc<2 && dsol>500&&!trackframe) carried_pixel = -1;
         }
         auto tmpticks = SDL_GetTicks();
         for (a=static_cast<int>(tmpticks%18); a<180+static_cast<int>(tmpticks%18); a+=18) // "Sole" centrale (il Solicchio).
@@ -1022,7 +1010,7 @@ bool main_loop() {
             Oggetti_sul_Pixel (1);
         }
 
-        if (!vicini&&globalvocfile[0]!='.') chiudi_filedriver ();
+        if (!vicini && globalvocfile[0]!='.') chiudi_filedriver ();
 
         if (trackframe==23)
             justloaded = 5;
@@ -1057,7 +1045,7 @@ bool main_loop() {
         }
 
 /*              if (sc) {
-                        rx = (double)alfa*Deg + micro_x;
+                        rx = (double)alpha*Deg + micro_x;
                         ry = (double)beta*Deg + micro_y;
                         cam_y -= sc * sin(rx);
                         cam_x += sc * sin(ry) * cos(rx);
@@ -1066,7 +1054,7 @@ bool main_loop() {
                 } */
 
         // handle object pick up request while flying
-        if (taking&&!extra) {
+        if (taking&&!EVA_in_progress) {
             kk = 500;
             obj = -1;
             for (u16 o=_objects-1; o>=0; o--) {
@@ -1083,7 +1071,7 @@ bool main_loop() {
             }
         }
 
-        if (taking&&obj>-1) {
+        if (taking && obj>-1) {
             coy = pixel_ydisloc[pix] + relative_y[obj] - object_elevation[objecttype[obj]];
             cox = pixel_xdisloc[pix] + relative_x[obj];
             coz = pixel_zdisloc[pix] + relative_z[obj];
@@ -1093,11 +1081,11 @@ bool main_loop() {
 
         // Disegno navicella e sua gestione.
    // Disegno navicella e sua gestione.
-    if (!extra) {
+    if (!EVA_in_progress) {
         nav_x = cam_x;
         nav_y = cam_y;
         nav_z = cam_z;
-        nav_a = 360 - alfa;
+        nav_a = 360 - alpha;
         if (nav_a==360) nav_a=0;
         nav_b = 360 - beta;
         if (nav_b==360) nav_b=0;
@@ -1110,9 +1098,9 @@ bool main_loop() {
 
     if (req_end_extra) {
         if (req_end_extra<50) req_end_extra++;
-        if (alfa>179) alfa-=360;
-        alfa = (double) alfa / 1.1;
-        if (alfa<0) alfa+=360;
+        if (alpha>179) alpha-=360;
+        alpha = (double) alpha / 1.1;
+        if (alpha<0) alpha+=360;
         auto p = ((360-nav_b) - beta) / 4;
         if (p)
             beta += (double) p;
@@ -1123,200 +1111,79 @@ bool main_loop() {
         alfad = 0;
         betad = 0;
         rel_x /= 1.25; rel_z /= 1.25;
-        if (alfa==0&&beta==360-nav_b
-                &&(rel_x<1&&rel_x>-1)
-                &&(rel_z<1&&rel_z>-1)
+        if (alpha==0 && beta==360-nav_b
+                &&(rel_x<1 && rel_x>-1)
+                &&(rel_z<1 && rel_z>-1)
                 &&req_end_extra>=24) {
             play (READY);
             subs = 0;
             req_end_extra = 0;
-            extra = 0;
+            EVA_in_progress = 0;
         }
     }
 
     if (tracking)
         trackframe += tracking;
 
-    if (echo&8) goto no_ind;
-
-    // Indicatori direzionali.
-    if (!trackframe) {
-        n (-1, -1, 18, -0.5, -0.5, 18); // "Mirino".
-        n (-1, 1, 18, -0.5, 0.5, 18);
-        n (1, -1, 18, 0.5, -0.5, 18);
-        n (1, 1, 18, 0.5, 0.5, 18);
+    // draw direction indicators if enabled
+    if (!(echo&8) && !trackframe) {
+        draw_indicator_crosshair();
+        // why do we need to run this code twice?
         for (c=0; c<2; c++) {
+            // prograde indicator
             if (C32(nav_x+spd_x, nav_y+spd_y, nav_z+spd_z)) {
-                if (share_x>5&&share_x<315&&share_y>5&&share_y<195) {
-                    Segmento (share_x - 5, share_y - 5, share_x + 5, share_y + 5);
-                    Segmento (share_x + 5, share_y - 5, share_x - 5, share_y + 5);
-                }
+                draw_indicator_prograde(share_x, share_y);
             }
             else {
+                // retrograde indicator
                 if (C32(nav_x-spd_x, nav_y-spd_y, nav_z-spd_z)) {
-                    if (share_x>10&&share_x<310&&share_y>10&&share_y<190) {
-                        Segmento (share_x - 9, share_y - 5, share_x + 9, share_y - 5);
-                        Segmento (share_x - 9, share_y + 5, share_x + 9, share_y + 5);
-                        Segmento (share_x - 5, share_y - 9, share_x - 5, share_y + 9);
-                        Segmento (share_x + 5, share_y - 9, share_x + 5, share_y + 9);
-                    }
+                   draw_indicator_retrograde(share_x, share_y);
                 }
             }
+            // closest pixel indicator
             if (pixel_absd[pix]>8000) {
                 if (C32(pixel_xdisloc[pix], pixel_ydisloc[pix], pixel_zdisloc[pix])) {
-                    if (share_x>20&&share_x<300&&share_y>20&&share_y<180) {
-                        Segmento (share_x, share_y - 19, share_x, share_y + 19);
-                        Segmento (share_x - 19, share_y, share_x + 19, share_y);
-                    }
+                    draw_indicator_closest(share_x, share_y);
                 }
             }
         }
     }
-
-    no_ind:
     
     // draw navigation HUD if enabled
     if (!(echo&2)) {
 
-        if (!extra) {
+        if (!EVA_in_progress) {
             tsinx += 361;
             tcosx += 361;
             tsiny += 361;
             tcosy += 361;
         }
 
-        // Pannello informativo.
-        nrect (0, 4.95, 12.01, 6, 0.95);
+        draw_vehicle_interior();
 
-        nrect (0, 4.95, 14, 6, 0.95);
-        n (-6, 4, 12.01, -6, 4, 14);
-        n ( 6, 4, 12.01,  6, 4, 14);
-        n (-6, 5.9, 12.01, -6, 5.9, 14);
-        n ( 6, 5.9, 12.01,  6, 5.9, 14);
-
-        // Parte anteriore della navicella.
-        nrect (0, 13.5, 58, 4, 2.5);
-
-        n (-10, 16, 16,  10, 16, 16);
-        n (-10, -5, 16, -10, 16, 16);
-        n ( 10, -5, 16,  10, 16, 16);
-        n (-10,  1, 25,  -4, 11, 58); //
-        n (-10,  1, 25, -10, -5, 16); ////
-        n (-10,  1, 25,-8.7, 16, 25); //////
-        //n ( -4, 11, 58,   4, 11, 58);
-        //n (  4, 11, 58,   4, 16, 58);
-        //n ( -4, 11, 58,  -4, 16, 58);
-        //n (  4, 16, 58,  -4, 16, 58);
-        n (  4, 11, 58,  10,  1, 25); //
-        n ( 10,  1, 25,  10, -5, 16); ////
-        n ( 10,  1, 25, 8.7, 16, 25); //////
-        n (  4, 16, 58,  10, 16, 16);
-        n ( -4, 16, 58, -10, 16, 16);
-        n ( -4, 16, 58,   0, 16, 83);
-        n (  0, 16, 83,   4, 16, 58);
-        n (  0, 16, 83,  -4, 11, 58);
-        n (  0, 16, 83,   4, 11, 58);
-        n (  0, 13, 64,  -4, 11, 58);
-        n (  0, 13, 64,   4, 11, 58);
-        n (  0, 13, 64,  -4, 16, 58);
-        n (  0, 13, 64,   4, 16, 58);
-
-        if (extra) {
-            // Attracchi.
-
-    /*                  _x = pixel_xdisloc[pix]+docksite_x[pixeltype[pix]];
-                        _y = pixel_ydisloc[pix]+docksite_y[pixeltype[pix]];
-                        _z = pixel_zdisloc[pix]+docksite_z[pixeltype[pix]];
-
-                        Line3D (nav_x-10, nav_y-5, nav_z+16, _x-50, _y, _z+50);
-                        Line3D (nav_x+10, nav_y-5, nav_z+16, _x+50, _y, _z+50);
-                        Line3D (nav_x-14, nav_y-10, nav_z-31, _x-50, _y, _z-50);
-                        Line3D (nav_x+14, nav_y-10, nav_z-31, _x+50, _y, _z-50); */
-
-            // Cabina.
-            n (-10,  -5,  16, -14, -10, -31);
-            n ( 10,  -5,  16,  14, -10, -31);
-            n (-10,  16,  16, -14,  16, -31);
-            n ( 10,  16,  16,  14,  16, -31);
-            n (-14, -10, -31,  14, -10, -31);
-            n (-14, -10, -31, -10,   0, -43);
-            n ( 14, -10, -31,  10,   0, -43);
-            n (  0,  16, -69, -10,   0, -43);
-            n (  0,  16, -69,  10,   0, -43);
-            n (  0,  16, -69, -10,  16, -43);
-            n (  0,  16, -69,  10,  16, -43);
-            n (-10,  16, -43, -14,  16, -31);
-            n ( 10,  16, -43,  14,  16, -31);
-            n (-10,   0, -43,  10,   0, -43);
-            n (-10,  16, -43,  10,  16, -43);
-            n (-10,   0, -43, -10,  16, -43);
-            n ( 10,   0, -43,  10,  16, -43);
-            n (-14, -10, -31, -14,  16, -31);
-            n ( 14, -10, -31,  14,  16, -31);
-
-            // Cupola della cabina.
-            n (-10,  -5,  16,  -6,  -9,   8);
-            n ( -6,  -9,   8,   6,  -9,   8);
-            n (  6,  -9,   8,  10,  -5,  16);
-            n ( -6,  -9,   8, -10, -14, -26);
-            n (-10, -14, -26, -14, -10, -31);
-            n (-10, -14, -26,  10, -14, -26);
-            n (  6,  -9,   8,  10, -14, -26);
-            n ( 10, -14, -26,  14, -10, -31);
-
-            // Ali.
-            n (-10, 16,  16, -40, 16, -55);
-            n (-40, 16, -55, -10, 16, -43);
-            n ( 10, 16,  16,  40, 16, -55);
-            n ( 40, 16, -55,  10, 16, -43);
-
+        if (EVA_in_progress) {
+            draw_vehicle_exterior();
         }
 
         // Sezione ridisegno pannello di controllo informativo.
         ox = nav_x; oy = nav_y; oz = nav_z;
 
-        char dist[20]; // Stringhe usate per conversioni.
-        sprintf (dist, "F=%04d/CGR", (int)spd);
-        nTxt (dist, -5.5, 4.5, 12.01, 0.07, 0.12);
+        draw_readings_force(spd);
 
-        if (!trackframe) sprintf (dist, "V=%04.0f:K/H", veloc*1.9656);
-        else sprintf (dist, "--DOCKED--" /*"ATTRACCATO"*/);
-        nTxt (dist, -5.5, 5.4, 12.01, 0.07, 0.12);
+        if (!trackframe) {
+            draw_readings_speed(veloc);
+        }
+        else draw_readings_docked();
 
-        sprintf (dist, "ASC=%03hd`", nav_b);
-        nTxt (dist, -2.25, 4.5, 12.01, 0.07, 0.12);
-        sprintf (dist, "DEC=%03hd`", nav_a);
-        nTxt (dist, -2.25, 5.4, 12.01, 0.07, 0.12);
+        draw_readings_heading(nav_a, nav_b);
+        draw_readings_position(cam_x, cam_y, cam_z);
 
-        sprintf (dist, "H=%1.1f:KM", -cam_y/33333.33333);
-        nTxt (dist, 0.35, 4.5, 12.01, 0.06, 0.12);
         kk = pixel_absd[pix]/33.33333333;
-        if (kk>1000)
-            sprintf (dist, "D=%1.1f:KM", kk/1000);
-        else
-            sprintf (dist, "D=%1.1f:MT", kk);
-        nTxt (dist, 0.35, 5.4, 12.01, 0.06, 0.12);
-
-        sprintf (dist, "X=%1.1f:KM", cam_x/33333.33333);
-        nTxt (dist, 3.1, 4.5, 12.01, 0.07, 0.12);
-        sprintf (dist, "Z=%1.1f:KM", cam_z/33333.33333);
-        nTxt (dist, 3.1, 5.4, 12.01, 0.07, 0.12);
+        draw_readings_closest(kk);
 
         // Disegno tasti funzione, interruttori e/m, ecc...
         if (!trackframe) {
-            nTxt ("N", -4, -4.5, 12.01, 0.07, 0.07);
-            nTxt ("S", -4, -3.5, 12.01, 0.07, 0.07);
-            nTxt ("E", -3.5, -4, 12.01, 0.07, 0.07);
-            nTxt ("W", -4.5, -4, 12.01, 0.07, 0.07);
-            n (-4-tcos[nav_b+270]/2, -4-tsin[nav_b+270]/2, 12.01, -4+tcos[nav_b+270], -4+tsin[nav_b+270], 12.01);
-            n (-4-tcos[nav_b+180]/2, -4-tsin[nav_b+180]/2, 12.01, -4+tcos[nav_b+180]/2, -4+tsin[nav_b+180]/2, 12.01);
-            nTxt ("Z", 4, -4.5, 12.01, 0.07, 0.07);
-            nTxt ("N", 4, -3.5, 12.01, 0.07, 0.07);
-            nTxt ("-", 4.5, -4, 12.01, 0.07, 0.07);
-            if (alfa>90&&alfa<270&&blink) nTxt ("*", 3.5, -4, 12.01, 0.07, 0.07);
-            i16 alfax = 359 - nav_a;
-            n (4-tcos[alfax]/2, -4-tsin[alfax]/2, 12.01, 4+tcos[alfax], -4+tsin[alfax], 12.01);
-            n (4-tcos[alfax+90]/2, -4-tsin[alfax+90]/2, 12.01, 4+tcos[alfax+90]/2, -4+tsin[alfax+90]/2, 12.01);
+           draw_vehicle_attitude(nav_a, nav_b, blink);
         }
 
         int bki0 = bki;
@@ -1325,26 +1192,26 @@ bool main_loop() {
         int bki3 = bki;
         int bki4 = bki;
 
-        if (!trackframe&&!extra&&i==58) bki0 = i;
-        if (!extra&&i==59&&!trackframe) bki1 = i;
-        if (trackframe&&i==60) bki2 = i;
-        if (trackframe&&!extra&&i==61) bki3 = i;
-        if (orig&&i==62) bki4 = i;
+        if (!trackframe && !EVA_in_progress && i==58) bki0 = i;
+        if (!EVA_in_progress && i==59 && !trackframe) bki1 = i;
+        if (trackframe && i==60) bki2 = i;
+        if (trackframe && !EVA_in_progress && i==61) bki3 = i;
+        if (orig && i==62) bki4 = i;
 
-        console_key ("SPIN", -6.0, 58, i, i, bki0);
-        console_key ("LEAD", -4.9, 59, i, i, bki1);
-        console_key ("EXTR", -3.8, 60, i, i, bki2);
-        console_key ("DOCK", -2.7, 61, i, i, bki3);
-        console_key ("ORIG", -1.6, 62, i, i, bki4);
+        draw_console_key ("SPIN", -6.0, 58, i, i, bki0);
+        draw_console_key ("LEAD", -4.9, 59, i, i, bki1);
+        draw_console_key ("EXTR", -3.8, 60, i, i, bki2);
+        draw_console_key ("DOCK", -2.7, 61, i, i, bki3);
+        draw_console_key ("ORIG", -1.6, 62, i, i, bki4);
 
-        console_key ("ECHO", 5.0, echo&1, 1, echo, bkecho);
+        draw_console_key ("ECHO", 5.0, echo&1, 1, echo, bkecho);
 
         // end drawing the fly
 
         bki = i;
         bkecho = echo;
 
-        if (!extra) {
+        if (!EVA_in_progress) {
             tsinx -= 361;
             tcosx -= 361;
             tsiny -= 361;
@@ -1447,7 +1314,7 @@ bool main_loop() {
             */
 
             /* Sound stuff
-            if (!extra&&!trackframe) { // Segnale dell'ecoscandaglio.
+            if (!EVA_in_progress&&!trackframe) { // Segnale dell'ecoscandaglio.
                 if (SDL_GetTicks()-stso>=gap) {
                     stso = SDL_GetTicks();
                     if (subs&&(echo&1)) play (SOTTOFONDO);
@@ -1697,7 +1564,7 @@ void build_cosm(char& flag)
     if (!flag) {
         //ctrlkeys[0] = 0;
         dropping = 1;
-        extra = 1;
+        EVA_in_progress = 1;
         _objects = 0;
         cout << "Object positioning taking place." << endl;
         for (int o=0; o<objects; o++) {
@@ -1736,7 +1603,7 @@ void build_cosm(char& flag)
         cout << "Percentage complete: 100" << endl;
 
         dropping = 0;
-        extra = 0;
+        EVA_in_progress = 0;
     }
 
 }
@@ -1833,7 +1700,7 @@ void load_situation(char i, bool skip_fade) {
         //sta_suonando = -1;
         //pixel_sonante = -1;
         //globalvocfile[0] = '.';
-        mx = beta * 5; my = alfa * 5;
+        mx = beta * 5; my = alpha * 5;
         r_x = rel_x; r_y = rel_y; r_z = rel_z;
 
         pclear (&video_buffer[0], 0);
@@ -1922,8 +1789,8 @@ void dists ()
 void ispd ()
 {
 
-    if (trackframe&&!extra) return;
-    if (!extra&&trackframe<23) {
+    if (trackframe&&!EVA_in_progress) return;
+    if (!EVA_in_progress && trackframe<23) {
         //spd = 2*spd + 1;
         spd = 1.5*spd + 0.5;
         if (spd>300) spd = 300;
@@ -1934,8 +1801,8 @@ void ispd ()
         // Sound off
         //if (acount<0&&!sbp_stat) play (PASSO);
         rel_y += acount / 300.0;
-        rel_x -= 4 * tsin[beta] * tcos[alfa];
-        rel_z += 4 * tcos[beta] * tcos[alfa];
+        rel_x -= 4 * tsin[beta] * tcos[alpha];
+        rel_z += 4 * tcos[beta] * tcos[alpha];
         if (docksite_h[pixeltype[pix]]>=0) {
             if (rel_x>docksite_w[pixeltype[pix]]-docksite_x[pixeltype[pix]]) rel_x = docksite_w[pixeltype[pix]]-docksite_x[pixeltype[pix]];
             if (rel_x<-docksite_x[pixeltype[pix]]-docksite_w[pixeltype[pix]]) rel_x = -docksite_x[pixeltype[pix]]-docksite_w[pixeltype[pix]];
@@ -1961,16 +1828,16 @@ void ispd ()
 /// When in a pixel, walk backward.
 void dspd ()
 {
-        if (trackframe&&!extra) return;
-        if (!extra&&trackframe<23)
+        if (trackframe&&!EVA_in_progress) return;
+        if (!EVA_in_progress && trackframe<23)
                 spd = 0;
         else {
                 // Sound off
                 //if (!sbp_stat) play (PASSO);
                 _x = rel_x;
                 _z = rel_z;
-                rel_x += 4 * tsin[beta] * tcos[alfa];
-                rel_z -= 4 * tcos[beta] * tcos[alfa];
+                rel_x += 4 * tsin[beta] * tcos[alpha];
+                rel_z -= 4 * tcos[beta] * tcos[alpha];
                 if (docksite_h[pixeltype[pix]]>=0) {
                         if (rel_x>docksite_w[pixeltype[pix]]-docksite_x[pixeltype[pix]]) rel_x = docksite_w[pixeltype[pix]]-docksite_x[pixeltype[pix]];
                         if (rel_x<-docksite_x[pixeltype[pix]]-docksite_w[pixeltype[pix]]) rel_x = -docksite_x[pixeltype[pix]]-docksite_w[pixeltype[pix]];
@@ -2003,7 +1870,7 @@ void attracco ()
 
 void undock ()
 {
-    if (!extra) {
+    if (!EVA_in_progress) {
         if (trackframe==23) {
             spd_x = pixel_xdisloc[pix] - prevpixx;
             spd_z = pixel_zdisloc[pix] - prevpixz;
@@ -2021,7 +1888,7 @@ void undock ()
 
 void extra_stop_extra ()
 {
-    if (extra) {
+    if (EVA_in_progress) {
         d = sqrt(rel_x*rel_x+(rel_z+10)*(rel_z+10));
         if (d<25) {
             req_end_extra = 1;
@@ -2031,13 +1898,13 @@ void extra_stop_extra ()
         }
     }
     else {
-        if (alfa==0&&trackframe==23&&req_end_extra==0) {
+        if (alpha==0 && trackframe==23 && req_end_extra==0) {
             if (!moving_last_object) {
                 play (FLY_OFF);
                 rel_x = 0;
                 rel_y = 7;
                 rel_z = 0;
-                extra = 1;
+                EVA_in_progress = 1;
                 dock_effects ();
             }
         }
@@ -2048,9 +1915,9 @@ void find_alfabeta()
 {
     kk = 1E9;
     for (c=0; c<360; c++) {
-        x2 = cam_x - 100 * tsin[c] * tcos[alfa];
-        z2 = cam_z + 100 * tcos[c] * tcos[alfa];
-        y2 = cam_y + 100 * tsin[alfa];
+        x2 = cam_x - 100 * tsin[c] * tcos[alpha];
+        z2 = cam_z + 100 * tcos[c] * tcos[alpha];
+        y2 = cam_y + 100 * tsin[alpha];
         ox = rx - x2; oy = ry - y2; oz = rz - z2;
         ox = ox*ox+oy*oy+oz*oz;
         if (ox<kk) {
@@ -2078,17 +1945,17 @@ void find_alfabeta()
 
 void fid_on ()
 {
-        if (extra||trackframe||fid||lead||orig) return;
-        rx = cam_x + 100 * tsin[beta] * tcos[alfa];
-        rz = cam_z - 100 * tcos[beta] * tcos[alfa];
-        ry = cam_y - 100 * tsin[alfa];
+        if (EVA_in_progress||trackframe||fid||lead||orig) return;
+        rx = cam_x + 100 * tsin[beta] * tcos[alpha];
+        rz = cam_z - 100 * tcos[beta] * tcos[alpha];
+        ry = cam_y - 100 * tsin[alpha];
         find_alfabeta ();
         fid = 1;
 }
 
 void lead_on ()
 {
-    if (extra||trackframe||fid||lead||orig) return;
+    if (EVA_in_progress||trackframe||fid||lead||orig) return;
     rx = cam_x + spd_x;
     ry = cam_y + spd_y;
     rz = cam_z + spd_z;
@@ -2098,7 +1965,7 @@ void lead_on ()
 
 void orig_on ()
 {
-    if (extra||trackframe||fid||lead||orig) return;
+    if (EVA_in_progress||trackframe||fid||lead||orig) return;
     rx = cam_x / 1.001;
     ry = cam_y / 1.001;
     rz = cam_z / 1.001;
@@ -2115,7 +1982,7 @@ void dock_effects ()
         ox = pixel_xdisloc[pix] + docksite_x[pixeltype[pix]] - cam_x;
         oz = pixel_zdisloc[pix] + docksite_z[pixeltype[pix]] - cam_z;
         oy = pixel_ydisloc[pix] + docksite_y[pixeltype[pix]] - 16 - cam_y;
-        if (oy<0&&!extra) cam_y = pixel_ydisloc[pix] + docksite_y[pixeltype[pix]] - 16;
+        if (oy<0&&!EVA_in_progress) cam_y = pixel_ydisloc[pix] + docksite_y[pixeltype[pix]] - 16;
         if (trackframe>12) tracking = 0.5;
         if (trackframe>21) tracking = 0.2;
         if (trackframe>22) tracking = 0.1;
@@ -2128,12 +1995,12 @@ void dock_effects ()
         cam_y += oy / (24-trackframe);
         cam_z += oz / (24-trackframe);
         dsx = cam_x; dsy = cam_y; dsz = cam_z;
-        if (fabs(oy)<152*fabs(tsin[alfa])&&!extra&&alfa) {
-            if (alfa>179) alfa-=360;
-            alfa = (double) alfa / 1.1;
-            if (alfa<0) alfa+=360;
+        if (fabs(oy)<152*fabs(tsin[alpha])&&!EVA_in_progress && alpha) {
+            if (alpha>179) alpha-=360;
+            alpha = (double) alpha / 1.1;
+            if (alpha<0) alpha+=360;
         }
-        if (extra) {
+        if (EVA_in_progress) {
             if (!req_end_extra)
                 dsy -= 36;
             else
@@ -2198,11 +2065,11 @@ void preleva_oggetto (int nr_ogg)
         return;
     }
 
-    if (globalvocfile[0]=='.'&&extra) play (PRENDERE);
+    if (globalvocfile[0]=='.'&&EVA_in_progress) play (PRENDERE);
 
     carry_type = objecttype[nr_ogg];
     // update pixel translation speed if picking up an orbital engine
-    if (extra&&object_location[nr_ogg]>-1&&carry_type==1)
+    if (EVA_in_progress && object_location[nr_ogg]>-1 && carry_type==1)
         pixel_rot[pix]--;
 
     // remove object and shift the others
@@ -2321,19 +2188,19 @@ void lascia_cadere ()
 {
     //int a;
 
-    if (trackframe&&!extra) return;
+    if (trackframe&&!EVA_in_progress) return;
     if (moving_last_object) return;
 
     objecttype[_objects] = carry_type;
 
-    if (extra) {
+    if (EVA_in_progress) {
         relative_x[_objects] = cox - prevpixx;
         relative_z[_objects] = coz - prevpixz;
         relative_y[_objects] = coy - pixel_ydisloc[pix] + object_elevation[carry_type];
         _x = rel_x;
         _z = rel_z;
-        rel_x -= 9 * tsin[beta] * tcos[alfa];
-        rel_z += 9 * tcos[beta] * tcos[alfa];
+        rel_x -= 9 * tsin[beta] * tcos[alpha];
+        rel_z += 9 * tcos[beta] * tcos[alpha];
         if (docksite_h[pixeltype[pix]]>=0) {
             if (rel_x>docksite_w[pixeltype[pix]]-docksite_x[pixeltype[pix]]) rel_x = docksite_w[pixeltype[pix]]-docksite_x[pixeltype[pix]];
             if (rel_x<-docksite_x[pixeltype[pix]]-docksite_w[pixeltype[pix]]) rel_x = -docksite_x[pixeltype[pix]]-docksite_w[pixeltype[pix]];
@@ -2376,20 +2243,20 @@ void lascia_cadere ()
     }
     else {
         object_location[_objects] = -1;
-        absolute_y[_objects] = cam_y + 9 * tsin[alfa];
-        absolute_x[_objects] = cam_x - 9 * tsin[beta] * tcos[alfa];
-        absolute_z[_objects] = cam_z + 9 * tcos[beta] * tcos[alfa];
+        absolute_y[_objects] = cam_y + 9 * tsin[alpha];
+        absolute_x[_objects] = cam_x - 9 * tsin[beta] * tcos[alpha];
+        absolute_z[_objects] = cam_z + 9 * tcos[beta] * tcos[alpha];
         relative_y[_objects] = spd_y;
         relative_x[_objects] = spd_x;
         relative_z[_objects] = spd_z;
         if (ctrlkeys[0]&64) {
-            relative_y[_objects] += 5 * tsin[alfa];
-            relative_x[_objects] -= 5 * tsin[beta] * tcos[alfa];
-            relative_z[_objects] += 5 * tcos[beta] * tcos[alfa];
+            relative_y[_objects] += 5 * tsin[alpha];
+            relative_x[_objects] -= 5 * tsin[beta] * tcos[alpha];
+            relative_z[_objects] += 5 * tcos[beta] * tcos[alpha];
         }
         /* Audio off
         if (subsignal[9*(carry_type+FRONTIER_M3)]) {
-            if (carry_type==sta_suonando&&fd_status) break; //goto noeli;
+            if (carry_type==sta_suonando && fd_status) break; //goto noeli;
             strcpy (t, &subsignal[9*(carry_type+FRONTIER_M3)]);
             strcat (t, ".voc");
             a = open (t, 0);
@@ -2406,110 +2273,6 @@ void lascia_cadere ()
     _objects++;
 }
 
-void n (double sx, double sy, double sz, double fx, double fy, double fz)
-{
-        z2 = sz * tcos[nav_a] + sy * tsin[nav_a];
-        sy = sy * tcos[nav_a] - sz * tsin[nav_a];
-        rx = sx * tcos[nav_b] + z2 * tsin[nav_b];
-        sz = z2 * tcos[nav_b] - sx * tsin[nav_b];
-        sx = rx;
-
-        z2 = fz * tcos[nav_a] + fy * tsin[nav_a];
-        fy = fy * tcos[nav_a] - fz * tsin[nav_a];
-        rx = fx * tcos[nav_b] + z2 * tsin[nav_b];
-        fz = z2 * tcos[nav_b] - fx * tsin[nav_b];
-        fx = rx;
-
-        sx += nav_x; sy += nav_y; sz += nav_z;
-        fx += nav_x; fy += nav_y; fz += nav_z;
-
-        Line3D (sx, sy, sz, fx, fy, fz);
-}
-
-void nTxt (const char *testo, double x, double y, double z, double sx, double sy)
-{
-        int c=0;
-        char transit[2] = {0, 0};
-        double ntx, nty, ntz;
-
-        z2 = z * tcos[nav_a] + y * tsin[nav_a];
-        ntx = x * tcos[nav_b] + z2 * tsin[nav_b];
-        nty = y * tcos[nav_a] - z * tsin[nav_a];
-        ntz = z2 * tcos[nav_b] - x * tsin[nav_b];
-
-        x += sx * mediumwidth;
-
-        z2 = z * tcos[nav_a] + y * tsin[nav_a];
-        double avan_x = x * tcos[nav_b] + z2 * tsin[nav_b];
-        double avan_y = y * tcos[nav_a] - z * tsin[nav_a];
-        double avan_z = z2 * tcos[nav_b] - x * tsin[nav_b];
-
-        avan_x -= ntx;
-        avan_y -= nty;
-        avan_z -= ntz;
-
-        while (testo[c]) {
-                transit[0] = testo[c];
-                Txt (transit, ntx, nty, ntz, sx, sy, nav_a, nav_b);
-                ntx += avan_x; nty += avan_y; ntz += avan_z;
-                c++;
-        }
-}
-
-void nrect (double x, double y, double z, double l, double h)
-{
-        n (x-l, y-h, z, x+l, y-h, z);
-        n (x+l, y-h, z, x+l, y+h, z);
-        n (x+l, y+h, z, x-l, y+h, z);
-        n (x-l, y+h, z, x-l, y-h, z);
-}
-
-void console_key (const char *serigraph, double x, char cod, char input, char cond_attu, char cond_prec)
-{
-        if (extra) {
-                // disable console keys when far away from the HUD
-                d = sqrt(rel_x*rel_x + (rel_z+10)*(rel_z+10));
-                if (d>25) {
-                        input = 1;
-                        cod = 0;
-                }
-        }
-
-        // only show console key as pressed when
-        // the key pressed is the same as the one bound to this console key
-        // AND the key wasn't already pressed in the previous frame
-        // (save for key code 1, which is a toggle button)
-        if (input!=cod || (cod != 1 && cond_attu == cond_prec)) {
-                n (x, 3.5, 12.01, x+1, 3.5, 12.01);
-                n (x, 3.5, 12.01, x, 4, 12.01);
-                n (x+1, 3.5, 12.01, x+1, 4, 12.01);
-                n (x, 3.5, 12.01, x, 4, 12.2);
-                n (x+1, 3.5, 12.01, x+1, 4, 12.2);
-                n (x, 4, 12.2, x+1, 4, 12.2);
-                n (x, 4, 12.01, x, 4, 12.2);
-                n (x+1, 4, 12.01, x+1, 4, 12.2);
-                nTxt (serigraph, x+0.2, 3.7, 12.01, 0.05, 0.05);
-        }
-        else {
-                nrect (x+0.5, 3.75, 12.31, 0.5, 0.25);
-                //n (x, 4, 12.31, x+1, 4, 12.31);
-                //n (x, 3.5, 12.31, x+1, 3.5, 12.31);
-                //n (x, 3.5, 12.31, x, 4, 12.31);
-                //n (x+1, 3.5, 12.31, x+1, 4, 12.31);
-                n (x, 3.5, 12.31, x, 4, 12.5);
-                n (x+1, 3.5, 12.31, x+1, 4, 12.5);
-                n (x, 4, 12.5, x+1, 4, 12.5);
-                n (x, 4, 12.31, x, 4, 12.5);
-                n (x+1, 4, 12.31, x+1, 4, 12.5);
-                nTxt (serigraph, x+0.2, 3.7, 12.31, 0.05, 0.05);
-                if (cond_attu!=cond_prec) {
-                        if (extra&&globalvocfile[0]!='.') return;
-                        //if (!sbp_stat) play (TASTO);
-                        subs = 0;
-                }
-        }
-}
-
 void collyblock (double cx, double cy, double cz,
                  double hx, double hy, double hz,
                  char blocktype)
@@ -2517,8 +2280,8 @@ void collyblock (double cx, double cy, double cz,
     if (!dropping) {
         r_y = rel_y;
         cx += ox; cy += oy; cz += oz;
-        if (cam_xt>=cx-hx&&cam_xt<=cx+hx) {
-            if (cam_zt>=cz-hz&&cam_zt<=cz+hz) {
+        if (cam_xt>=cx-hx && cam_xt<=cx+hx) {
+            if (cam_zt>=cz-hz && cam_zt<=cz+hz) {
                 if ((blocktype==BLOCCO_ELEVATO||blocktype==SOLID_BOX)&&(cam_yt+45>cy+hy))
                     return;
                 onblock = 1;
@@ -2549,8 +2312,8 @@ void collyblock (double cx, double cy, double cz,
             }
         }
         else {
-            if (rel_x>=cx-hx&&rel_x<=cx+hx) {
-                if (rel_z>=cz-hz&&rel_z<=cz+hz) {
+            if (rel_x>=cx-hx && rel_x<=cx+hx) {
+                if (rel_z>=cz-hz && rel_z<=cz+hz) {
                     if (blocktype==BLOCCO_ELEVATO || blocktype == SOLID_BOX) return;
                     if (blocktype==BLOCCO_PROIBITO)
                         onblock = 2;
@@ -2636,9 +2399,9 @@ trovato:while (nr_elem<pixeltype_elements[iii]) {
                 for (o=_objects-1; o>=0; o--) {
                         // ctrlkeys[0]&64 is Caps Lock
                         if (object_location[o]==nopix&&(pixelmass[objecttype[o]+FRONTIER_M3]<100||(ctrlkeys[0]&64))) {
-                                _x = (relative_x[o] + pixel_xdisloc[nopix]) - (cam_xt - 10 * tsin[beta] * tcos[alfa]);
-                                _y = (relative_y[o] + pixel_ydisloc[nopix] - object_elevation[objecttype[o]]) - (cam_yt + 10 * tsin[alfa]);
-                                _z = (relative_z[o] + pixel_zdisloc[nopix]) - (cam_zt + 10 * tcos[beta] * tcos[alfa]);
+                                _x = (relative_x[o] + pixel_xdisloc[nopix]) - (cam_xt - 10 * tsin[beta] * tcos[alpha]);
+                                _y = (relative_y[o] + pixel_ydisloc[nopix] - object_elevation[objecttype[o]]) - (cam_yt + 10 * tsin[alpha]);
+                                _z = (relative_z[o] + pixel_zdisloc[nopix]) - (cam_zt + 10 * tcos[beta] * tcos[alpha]);
                                 _y /= 3;
                                 d = sqrt (_x*_x+_y*_y+_z*_z);
                                 if (d<kk) {
@@ -3233,7 +2996,7 @@ void Object (int tipo)
                         /*
                         if (tasto_premuto()) {
                             c = attendi_pressione_tasto();
-                            if ((globalvocfile[0]=='.'&&extra)||!extra) play (TARGET);
+                            if ((globalvocfile[0]=='.'&&EVA_in_progress)||!EVA_in_progress) play (TARGET);
                             switch (c) {
                                 case 0:
                                     switch (attendi_pressione_tasto()) {
@@ -3271,7 +3034,7 @@ void Object (int tipo)
                         default:
                             if (cursore<512) {
                                 if (c>='a'&&c<='z') c -= 32;
-                                if (c>31&&c<97) {
+                                if (c>31 && c<97) {
                                     buffer[cursore+33] = c;
                                     if (cursore<511) cursore++;
                                 }

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -2528,38 +2528,41 @@ ogg_2:
                     p3 *= id+1;
                     switch (static_cast<int>(p4)) {
                         case 0:
-                            a = c; k1 = 0;
+                            a = c;
+                            k0 = 0; k1 = p3;
                             crx = c; cry = 0;
                             while (a<1080) {
                                 rel (p0+k1*tcos[(int)crx], p1+k1*tsin[(int)crx], p2,
-                                        p0+k1*tcos[(int)cry], p1+k1*tsin[(int)cry], p2);
+                                        p0+k0*tcos[(int)cry], p1+k0*tsin[(int)cry], p2);
                                 cry = crx; crx += c;
                                 if (crx>359) crx-=360;
-                                k1 += p3;
+                                k0 += p3; k1 += p3;
                                 a += c;
                             }
                             break;
                         case 1:
-                            a = c; k1 = 0;
+                            a = c;
+                            k0 = 0; k1 = p3;
                             crx = c; cry = 0;
                             while (a<1080) {
                                 rel (p0+k1*tcos[(int)crx], p1, p2+k1*tsin[(int)crx],
-                                        p0+k1*tcos[(int)cry], p1, p2+k1*tsin[(int)cry]);
+                                        p0+k0*tcos[(int)cry], p1, p2+k0*tsin[(int)cry]);
                                 cry = crx; crx += c;
                                 if (crx>359) crx-=360;
-                                k1 += p3;
+                                k0 += p3; k1 += p3;
                                 a += c;
                             }
                             break;
                         case 2:
-                            a = c; k1 = 0;
+                            a = c;
+                            k0 = 0; k1 = p3;
                             crx = c; cry = 0;
                             while (a<1080) {
                                 rel (p0, p1+k1*tcos[(int)crx], p2+k1*tsin[(int)crx], p0,
-                                        p1+k1*tcos[(int)cry], p2+k1*tsin[(int)cry]);
+                                        p1+k0*tcos[(int)cry], p2+k0*tsin[(int)cry]);
                                 cry = crx; crx += c;
                                 if (crx>359) crx-=360;
-                                k1 += p3;
+                                k0 += p3; k1 += p3;
                                 a += c;
                             }
                         }

--- a/source/draw.cpp
+++ b/source/draw.cpp
@@ -1,0 +1,319 @@
+/** \file draw.cpp
+ *  This file is part of Crystal Pixels.
+ *
+ *  Crystal Pixels is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Crystal Pixels is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "draw.h"
+#include "global.h"
+#include "fast3d.h"
+#include "text3d.h"
+
+void draw_line_relative (double sx, double sy, double sz, double fx, double fy, double fz)
+{
+        z2 = sz * tcos[nav_a] + sy * tsin[nav_a];
+        sy = sy * tcos[nav_a] - sz * tsin[nav_a];
+        rx = sx * tcos[nav_b] + z2 * tsin[nav_b];
+        sz = z2 * tcos[nav_b] - sx * tsin[nav_b];
+        sx = rx;
+
+        z2 = fz * tcos[nav_a] + fy * tsin[nav_a];
+        fy = fy * tcos[nav_a] - fz * tsin[nav_a];
+        rx = fx * tcos[nav_b] + z2 * tsin[nav_b];
+        fz = z2 * tcos[nav_b] - fx * tsin[nav_b];
+        fx = rx;
+
+        sx += nav_x; sy += nav_y; sz += nav_z;
+        fx += nav_x; fy += nav_y; fz += nav_z;
+
+        Line3D (sx, sy, sz, fx, fy, fz);
+}
+
+void draw_text_relative (const char *testo, double x, double y, double z, double sx, double sy)
+{
+        int c=0;
+        char transit[2] = {0, 0};
+        double ntx, nty, ntz;
+
+        z2 = z * tcos[nav_a] + y * tsin[nav_a];
+        ntx = x * tcos[nav_b] + z2 * tsin[nav_b];
+        nty = y * tcos[nav_a] - z * tsin[nav_a];
+        ntz = z2 * tcos[nav_b] - x * tsin[nav_b];
+
+        x += sx * mediumwidth;
+
+        z2 = z * tcos[nav_a] + y * tsin[nav_a];
+        double avan_x = x * tcos[nav_b] + z2 * tsin[nav_b];
+        double avan_y = y * tcos[nav_a] - z * tsin[nav_a];
+        double avan_z = z2 * tcos[nav_b] - x * tsin[nav_b];
+
+        avan_x -= ntx;
+        avan_y -= nty;
+        avan_z -= ntz;
+
+        while (testo[c]) {
+                transit[0] = testo[c];
+                Txt (transit, ntx, nty, ntz, sx, sy, nav_a, nav_b);
+                ntx += avan_x; nty += avan_y; ntz += avan_z;
+                c++;
+        }
+}
+
+void draw_rect_relative (double x, double y, double z, double l, double h)
+{
+        draw_line_relative (x-l, y-h, z, x+l, y-h, z);
+        draw_line_relative (x+l, y-h, z, x+l, y+h, z);
+        draw_line_relative (x+l, y+h, z, x-l, y+h, z);
+        draw_line_relative (x-l, y+h, z, x-l, y-h, z);
+}
+
+void draw_console_key (const char *serigraph, double x, char cod, char input, char current_state, char previous_state)
+{
+        if (EVA_in_progress) {
+                // disable console keys when far away from the HUD
+                d = sqrt(rel_x*rel_x + (rel_z+10)*(rel_z+10));
+                if (d>25) {
+                        input = 1;
+                        cod = 0;
+                }
+        }
+
+        // only show console key as pressed when
+        // the key pressed is the same as the one bound to this console key
+        // AND the key wasn't already pressed in the previous frame
+        // (save for key code 1, which is a toggle button)
+        if (input!=cod || (cod != 1 && current_state == previous_state)) {
+                draw_line_relative (x, 3.5, 12.01, x+1, 3.5, 12.01);
+                draw_line_relative (x, 3.5, 12.01, x, 4, 12.01);
+                draw_line_relative (x+1, 3.5, 12.01, x+1, 4, 12.01);
+                draw_line_relative (x, 3.5, 12.01, x, 4, 12.2);
+                draw_line_relative (x+1, 3.5, 12.01, x+1, 4, 12.2);
+                draw_line_relative (x, 4, 12.2, x+1, 4, 12.2);
+                draw_line_relative (x, 4, 12.01, x, 4, 12.2);
+                draw_line_relative (x+1, 4, 12.01, x+1, 4, 12.2);
+                draw_text_relative (serigraph, x+0.2, 3.7, 12.01, 0.05, 0.05);
+        }
+        else {
+                draw_rect_relative (x+0.5, 3.75, 12.31, 0.5, 0.25);
+                //draw_line_relative (x, 4, 12.31, x+1, 4, 12.31);
+                //draw_line_relative (x, 3.5, 12.31, x+1, 3.5, 12.31);
+                //draw_line_relative (x, 3.5, 12.31, x, 4, 12.31);
+                //draw_line_relative (x+1, 3.5, 12.31, x+1, 4, 12.31);
+                draw_line_relative (x, 3.5, 12.31, x, 4, 12.5);
+                draw_line_relative (x+1, 3.5, 12.31, x+1, 4, 12.5);
+                draw_line_relative (x, 4, 12.5, x+1, 4, 12.5);
+                draw_line_relative (x, 4, 12.31, x, 4, 12.5);
+                draw_line_relative (x+1, 4, 12.31, x+1, 4, 12.5);
+                draw_text_relative (serigraph, x+0.2, 3.7, 12.31, 0.05, 0.05);
+                if (current_state!=previous_state) {
+                        if (EVA_in_progress && globalvocfile[0]!='.') return;
+                        //if (!sbp_stat) play (TASTO);
+                        subs = 0;
+                }
+        }
+}
+
+void draw_indicator_crosshair()
+{
+    draw_line_relative (-1, -1, 18, -0.5, -0.5, 18);
+    draw_line_relative (-1, 1, 18, -0.5, 0.5, 18);
+    draw_line_relative (1, -1, 18, 0.5, -0.5, 18);
+    draw_line_relative (1, 1, 18, 0.5, 0.5, 18);
+}
+
+void draw_indicator_prograde(int x, int y)
+{
+    if ( x>5 && x<315 && y>5 && y<195) {
+        Segmento (x - 5, y - 5, x + 5, y + 5);
+        Segmento (x + 5, y - 5, x - 5, y + 5);
+    }
+}
+
+void draw_indicator_retrograde(int x, int y)
+{
+    if ( x>10 && x<310 && y>10 && y<190) {
+        Segmento (x - 9, y - 5, x + 9, y - 5);
+        Segmento (x - 9, y + 5, x + 9, y + 5);
+        Segmento (x - 5, y - 9, x - 5, y + 9);
+        Segmento (x + 5, y - 9, x + 5, y + 9);
+    }
+}
+
+void draw_indicator_closest(int x, int y)
+{
+    if ( x>20 && x<300 && y>20 && y<180) {
+        Segmento (x, y - 19, x, y + 19);
+        Segmento (x - 19, y, x + 19, y);
+    }
+}
+
+void draw_vehicle_interior()
+{
+    // info panel without readings
+    draw_rect_relative (0, 4.95, 12.01, 6, 0.95);
+
+    draw_rect_relative (0, 4.95, 14, 6, 0.95);
+    draw_line_relative (-6, 4, 12.01, -6, 4, 14);
+    draw_line_relative ( 6, 4, 12.01,  6, 4, 14);
+    draw_line_relative (-6, 5.9, 12.01, -6, 5.9, 14);
+    draw_line_relative ( 6, 5.9, 12.01,  6, 5.9, 14);
+
+    // ship's front section
+    draw_rect_relative (0, 13.5, 58, 4, 2.5);
+
+    draw_line_relative (-10, 16, 16,  10, 16, 16);
+    draw_line_relative (-10, -5, 16, -10, 16, 16);
+    draw_line_relative ( 10, -5, 16,  10, 16, 16);
+    draw_line_relative (-10,  1, 25,  -4, 11, 58);
+    draw_line_relative (-10,  1, 25, -10, -5, 16);
+    draw_line_relative (-10,  1, 25,-8.7, 16, 25);
+    //draw_line_relative ( -4, 11, 58,   4, 11, 58);
+    //draw_line_relative (  4, 11, 58,   4, 16, 58);
+    //draw_line_relative ( -4, 11, 58,  -4, 16, 58);
+    //draw_line_relative (  4, 16, 58,  -4, 16, 58);
+    draw_line_relative (  4, 11, 58,  10,  1, 25);
+    draw_line_relative ( 10,  1, 25,  10, -5, 16);
+    draw_line_relative ( 10,  1, 25, 8.7, 16, 25);
+    draw_line_relative (  4, 16, 58,  10, 16, 16);
+    draw_line_relative ( -4, 16, 58, -10, 16, 16);
+    draw_line_relative ( -4, 16, 58,   0, 16, 83);
+    draw_line_relative (  0, 16, 83,   4, 16, 58);
+    draw_line_relative (  0, 16, 83,  -4, 11, 58);
+    draw_line_relative (  0, 16, 83,   4, 11, 58);
+    draw_line_relative (  0, 13, 64,  -4, 11, 58);
+    draw_line_relative (  0, 13, 64,   4, 11, 58);
+    draw_line_relative (  0, 13, 64,  -4, 16, 58);
+    draw_line_relative (  0, 13, 64,   4, 16, 58);
+}
+
+void draw_vehicle_exterior()
+{
+    // Attracchi.
+    /*  
+    _x = pixel_xdisloc[pix]+docksite_x[pixeltype[pix]];
+    _y = pixel_ydisloc[pix]+docksite_y[pixeltype[pix]];
+    _z = pixel_zdisloc[pix]+docksite_z[pixeltype[pix]];
+
+    Line3D (nav_x-10, nav_y-5, nav_z+16, _x-50, _y, _z+50);
+    Line3D (nav_x+10, nav_y-5, nav_z+16, _x+50, _y, _z+50);
+    Line3D (nav_x-14, nav_y-10, nav_z-31, _x-50, _y, _z-50);
+    Line3D (nav_x+14, nav_y-10, nav_z-31, _x+50, _y, _z-50);
+    */
+
+    // Cabina.
+    draw_line_relative (-10,  -5,  16, -14, -10, -31);
+    draw_line_relative ( 10,  -5,  16,  14, -10, -31);
+    draw_line_relative (-10,  16,  16, -14,  16, -31);
+    draw_line_relative ( 10,  16,  16,  14,  16, -31);
+    draw_line_relative (-14, -10, -31,  14, -10, -31);
+    draw_line_relative (-14, -10, -31, -10,   0, -43);
+    draw_line_relative ( 14, -10, -31,  10,   0, -43);
+    draw_line_relative (  0,  16, -69, -10,   0, -43);
+    draw_line_relative (  0,  16, -69,  10,   0, -43);
+    draw_line_relative (  0,  16, -69, -10,  16, -43);
+    draw_line_relative (  0,  16, -69,  10,  16, -43);
+    draw_line_relative (-10,  16, -43, -14,  16, -31);
+    draw_line_relative ( 10,  16, -43,  14,  16, -31);
+    draw_line_relative (-10,   0, -43,  10,   0, -43);
+    draw_line_relative (-10,  16, -43,  10,  16, -43);
+    draw_line_relative (-10,   0, -43, -10,  16, -43);
+    draw_line_relative ( 10,   0, -43,  10,  16, -43);
+    draw_line_relative (-14, -10, -31, -14,  16, -31);
+    draw_line_relative ( 14, -10, -31,  14,  16, -31);
+
+    // Cupola della cabina.
+    draw_line_relative (-10,  -5,  16,  -6,  -9,   8);
+    draw_line_relative ( -6,  -9,   8,   6,  -9,   8);
+    draw_line_relative (  6,  -9,   8,  10,  -5,  16);
+    draw_line_relative ( -6,  -9,   8, -10, -14, -26);
+    draw_line_relative (-10, -14, -26, -14, -10, -31);
+    draw_line_relative (-10, -14, -26,  10, -14, -26);
+    draw_line_relative (  6,  -9,   8,  10, -14, -26);
+    draw_line_relative ( 10, -14, -26,  14, -10, -31);
+
+    // Ali.
+    draw_line_relative (-10, 16,  16, -40, 16, -55);
+    draw_line_relative (-40, 16, -55, -10, 16, -43);
+    draw_line_relative ( 10, 16,  16,  40, 16, -55);
+    draw_line_relative ( 40, 16, -55,  10, 16, -43);
+}
+
+void draw_readings_force(double force)
+{
+    char str[20];
+    sprintf (str, "F=%04d/CGR", (int) force);
+    draw_text_relative (str, -5.5, 4.5, 12.01, 0.07, 0.12);
+}
+
+void draw_readings_speed(double speed)
+{
+    char str[20];
+    sprintf (str, "V=%04.0f:K/H", speed*1.9656);
+    draw_text_relative (str, -5.5, 5.4, 12.01, 0.07, 0.12);
+}
+
+void draw_readings_docked()
+{
+    char str[20];
+    sprintf (str, "--DOCKED--");
+    draw_text_relative (str, -5.5, 5.4, 12.01, 0.07, 0.12);
+}
+
+void draw_readings_heading(i16 alpha, i16 beta)
+{
+    char str[20];
+    sprintf (str, "ASC=%03hd`", beta);
+    draw_text_relative (str, -2.25, 4.5, 12.01, 0.07, 0.12);
+    sprintf (str, "DEC=%03hd`", alpha);
+    draw_text_relative (str, -2.25, 5.4, 12.01, 0.07, 0.12);
+}
+
+void draw_readings_position(double x, double y, double z)
+{
+    char str[20];
+    sprintf (str, "H=%1.1f:KM", -y/33333.33333);
+    draw_text_relative (str, 0.35, 4.5, 12.01, 0.06, 0.12);
+    sprintf (str, "X=%1.1f:KM", x/33333.33333);
+    draw_text_relative (str, 3.1, 4.5, 12.01, 0.07, 0.12);
+    sprintf (str, "Z=%1.1f:KM", z/33333.33333);
+    draw_text_relative (str, 3.1, 5.4, 12.01, 0.07, 0.12);
+}
+
+void draw_readings_closest(double distance)
+{
+    char str[20];
+    if (distance>1000)
+        sprintf (str, "D=%1.1f:KM", distance/1000);
+    else
+        sprintf (str, "D=%1.1f:MT", distance);
+    draw_text_relative (str, 0.35, 5.4, 12.01, 0.06, 0.12);
+}
+
+void draw_vehicle_attitude(i16 alpha, i16 beta, char blink)
+{
+    draw_text_relative ("N", -4, -4.5, 12.01, 0.07, 0.07);
+    draw_text_relative ("S", -4, -3.5, 12.01, 0.07, 0.07);
+    draw_text_relative ("E", -3.5, -4, 12.01, 0.07, 0.07);
+    draw_text_relative ("W", -4.5, -4, 12.01, 0.07, 0.07);
+    draw_line_relative (-4-tcos[beta+270]/2, -4-tsin[beta+270]/2, 12.01, -4+tcos[beta+270], -4+tsin[beta+270], 12.01);
+    draw_line_relative (-4-tcos[beta+180]/2, -4-tsin[beta+180]/2, 12.01, -4+tcos[beta+180]/2, -4+tsin[beta+180]/2, 12.01);
+    draw_text_relative ("Z", 4, -4.5, 12.01, 0.07, 0.07);
+    draw_text_relative ("N", 4, -3.5, 12.01, 0.07, 0.07);
+    draw_text_relative ("-", 4.5, -4, 12.01, 0.07, 0.07);
+    if ( alpha>90 && alpha<270 && blink)
+        draw_text_relative ("*", 3.5, -4, 12.01, 0.07, 0.07);
+    i16 alfax = 359 - alpha;
+    draw_line_relative (4-tcos[alfax]/2, -4-tsin[alfax]/2, 12.01, 4+tcos[alfax], -4+tsin[alfax], 12.01);
+    draw_line_relative (4-tcos[alfax+90]/2, -4-tsin[alfax+90]/2, 12.01, 4+tcos[alfax+90]/2, -4+tsin[alfax+90]/2, 12.01);
+}

--- a/source/draw.cpp
+++ b/source/draw.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "draw.h"
+#include "conf.h"
 #include "global.h"
 #include "fast3d.h"
 #include "text3d.h"
@@ -134,27 +135,46 @@ void draw_indicator_crosshair()
 
 void draw_indicator_prograde(int x, int y)
 {
-    if ( x>5 && x<315 && y>5 && y<195) {
-        Segmento (x - 5, y - 5, x + 5, y + 5);
-        Segmento (x + 5, y - 5, x - 5, y + 5);
+    static const int width = 5*HEIGHT/200;
+
+    static const int xlow = 5*WIDTH/320;
+    static const int xhigh = 315*WIDTH/320;
+    static const int ylow = xlow;
+    static const int yhigh = 195*HEIGHT/200; 
+    if ( x>xlow && x<xhigh && y>ylow && y<yhigh) {
+        Segmento (x - width, y - width, x + width, y + width);
+        Segmento (x + width, y - width, x - width, y + width);
     }
 }
 
 void draw_indicator_retrograde(int x, int y)
 {
-    if ( x>10 && x<310 && y>10 && y<190) {
-        Segmento (x - 9, y - 5, x + 9, y - 5);
-        Segmento (x - 9, y + 5, x + 9, y + 5);
-        Segmento (x - 5, y - 9, x - 5, y + 9);
-        Segmento (x + 5, y - 9, x + 5, y + 9);
+    static const int outside = 9*HEIGHT/200;
+    static const int inside  = 5*HEIGHT/200;
+
+    static const int xlow = 10*WIDTH/320;
+    static const int xhigh = 310*WIDTH/320;
+    static const int ylow = xlow;
+    static const int yhigh = 190*HEIGHT/200; 
+    if ( x>xlow && x<xhigh && y>ylow && y<yhigh) {
+        Segmento (x - outside, y - inside, x + outside, y - inside);
+        Segmento (x - outside, y + inside, x + outside, y + inside);
+        Segmento (x - inside, y - outside, x - inside, y + outside);
+        Segmento (x + inside, y - outside, x + inside, y + outside);
     }
 }
 
 void draw_indicator_closest(int x, int y)
 {
-    if ( x>20 && x<300 && y>20 && y<180) {
-        Segmento (x, y - 19, x, y + 19);
-        Segmento (x - 19, y, x + 19, y);
+    static const int width = 19*HEIGHT/200;
+
+    static const int xlow = 20*WIDTH/320;
+    static const int xhigh = 300*WIDTH/320;
+    static const int ylow = xlow;
+    static const int yhigh = 180*HEIGHT/200; 
+    if ( x>xlow && x<xhigh && y>ylow && y<yhigh) {
+        Segmento (x, y - width, x, y + width);
+        Segmento (x - width, y, x + width, y);
     }
 }
 
@@ -313,7 +333,7 @@ void draw_vehicle_attitude(i16 alpha, i16 beta, char blink)
     draw_text_relative ("-", 4.5, -4, 12.01, 0.07, 0.07);
     if ( alpha>90 && alpha<270 && blink)
         draw_text_relative ("*", 3.5, -4, 12.01, 0.07, 0.07);
-    i16 alfax = 359 - alpha;
-    draw_line_relative (4-tcos[alfax]/2, -4-tsin[alfax]/2, 12.01, 4+tcos[alfax], -4+tsin[alfax], 12.01);
-    draw_line_relative (4-tcos[alfax+90]/2, -4-tsin[alfax+90]/2, 12.01, 4+tcos[alfax+90]/2, -4+tsin[alfax+90]/2, 12.01);
+    i16 alphax = 359 - alpha;
+    draw_line_relative (4-tcos[alphax]/2, -4-tsin[alphax]/2, 12.01, 4+tcos[alphax], -4+tsin[alphax], 12.01);
+    draw_line_relative (4-tcos[alphax+90]/2, -4-tsin[alphax+90]/2, 12.01, 4+tcos[alphax+90]/2, -4+tsin[alphax+90]/2, 12.01);
 }

--- a/source/draw.cpp
+++ b/source/draw.cpp
@@ -276,10 +276,13 @@ void draw_readings_force(double force)
     draw_text_relative (str, -5.5, 4.5, 12.01, 0.07, 0.12);
 }
 
+// conversion factor from units per frame to km/h:
+// 1 unit/frame = 0.90 m/s at 30 frames/s
+// which means 1 unit/frame = 3.24 km/h (the original value was 1.9656)
 void draw_readings_speed(double speed)
 {
     char str[20];
-    sprintf (str, "V=%04.0f:K/H", speed*1.9656);
+    sprintf (str, "V=%04.0f:K/H", speed*3.24);
     draw_text_relative (str, -5.5, 5.4, 12.01, 0.07, 0.12);
 }
 

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -43,7 +43,7 @@ double cam_x = 0;
 double cam_y = 0;
 double cam_z = 0;
 
-i16 alfa  = 0;
+i16 alpha  = 0;
 i16 beta  = 0;
 
 double kk;
@@ -407,22 +407,22 @@ void Line3D (double p_x, double p_y, double p_z,
     p_z -= cam_z;
 
     p_z2 = p_z * tcos[beta] - p_x * tsin[beta];
-    p_rz = p_z2 * tcos[alfa] + p_y * tsin[alfa];
+    p_rz = p_z2 * tcos[alpha] + p_y * tsin[alpha];
 
     x -= cam_x;
     y -= cam_y;
     z -= cam_z;
 
     z2 = z * tcos[beta] - x * tsin[beta];
-    rz = z2 * tcos[alfa] + y * tsin[alfa];
+    rz = z2 * tcos[alpha] + y * tsin[alpha];
 
-    if (rz<uneg&&p_rz<uneg) return;
+    if (rz<uneg && p_rz<uneg) return;
 
     p_rx = p_x * tcosx[beta] + p_z * tsinx[beta];
-    p_ry = p_y * tcosy[alfa] - p_z2 * tsiny[alfa];
+    p_ry = p_y * tcosy[alpha] - p_z2 * tsiny[alpha];
 
     rx = x * tcosx[beta] + z * tsinx[beta];
-    ry = y * tcosy[alfa] - z2 * tsiny[alfa];
+    ry = y * tcosy[alpha] - z2 * tsiny[alpha];
 
     /* Conversione punti alle spalle dell'osservatore rispetto al piano
        dello schermo. */
@@ -524,7 +524,7 @@ void Line3D (double p_x, double p_y, double p_z,
         }
     }
 
-    if (fx==lx&&fy==ly) return; // Esclude le linee costituite da un punto solo.
+    if (fx==lx && fy==ly) return; // Esclude le linee costituite da un punto solo.
 
     if (fy<lowerbound_y||ly<lowerbound_y) return; // Esclude le linee che mai e poi mai si vedranno.
     if (fy>upperbound_y||ly>upperbound_y) return;
@@ -541,11 +541,11 @@ int C32 (double x, double y, double z)
     z -= cam_z;
 
     z2 = z * tcos[beta] - x * tsin[beta];
-    rz = z2 * tcos[alfa] + y * tsin[alfa];
+    rz = z2 * tcos[alpha] + y * tsin[alpha];
 
     if (rz<uneg) return 0; // Il punto non si vede. Inutile continuare.
 
-    ry = y * tcosy[alfa] - z2 * tsiny[alfa];
+    ry = y * tcosy[alpha] - z2 * tsiny[alpha];
     share_y = ry / rz;
 
     if (share_y<lowerbound_y || share_y>upperbound_y)

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -105,11 +105,11 @@ PixelTypeId* pixeltype; // Tipo di pixel, da 0 a existent_pixeltypes-1.
 
 u8* pixel_rot; // Flag di rotazione attorno al Solicchio.
 
-float far  *pixel_absd;    // Distanza assoluta dall'osservatore.
-double far *pixel_support; // Supporto per quel pixel (piccola memoria).
-double far *pixel_xdisloc; // Posizione X.
-double far *pixel_ydisloc; //     -     Y.
-double far *pixel_zdisloc; //     -     Z.
+float  *pixel_absd;    // Distanza assoluta dall'osservatore.
+double *pixel_support; // Supporto per quel pixel (piccola memoria).
+double *pixel_xdisloc; // Posizione X.
+double *pixel_ydisloc; //     -     Y.
+double *pixel_zdisloc; //     -     Z.
 
 // Definizioni comode.
 
@@ -132,7 +132,7 @@ const int FRONTIER_COMPL_M1 = 649 - FRONTIER;
 // Warning: this constant is likely outdated, do not rely on it
 const int MEMORIA_RICHIESTA = 251901 + 81*ELEMS*BUFFERS + 3*BUFFERS;
 
-//unsigned char far *ctrlkeys = (unsigned char far *) 0x417;
+//unsigned char *ctrlkeys = (unsigned char *) 0x417;
 
 /* Descrizione dei tipi di pixel
    (<BUFFERS> tipi caricati per volta, <ELEMS> elementi per tipo). */
@@ -141,8 +141,8 @@ u8 *buffer; // Buffer per la ricerca degli Id.
 
 u8 loaded_pixeltypes;       // Tipi di pixel caricati.
 
-PixelTypeId far *pixeltype_type;      // Che tipo di pixel ha questa definizione?
-u8 far *pixeltype_elements; // Quanti elementi contiene la definizione?
+PixelTypeId *pixeltype_type;      // Che tipo di pixel ha questa definizione?
+u8 *pixeltype_elements; // Quanti elementi contiene la definizione?
 
 const char* comspec[COMS] = {
 "ENDPIXEL", // FINEPIXEL
@@ -201,30 +201,30 @@ const u8 params[COMS] = {
 
 u8* pixel_elem_t;   // Tipo di elemento.
 
-double far *pixel_elem_x; // Coordinate relative al pixel.
-double far *pixel_elem_y;
-double far *pixel_elem_z;
-float  far *pixel_elem_1; // Parametri speciali (l, h, p, r, orient) ...
-float  far *pixel_elem_2;
-float  far *pixel_elem_3;
-float  far *pixel_elem_4;
+double *pixel_elem_x; // Coordinate relative al pixel.
+double *pixel_elem_y;
+double *pixel_elem_z;
+float  *pixel_elem_1; // Parametri speciali (l, h, p, r, orient) ...
+float  *pixel_elem_2;
+float  *pixel_elem_3;
+float  *pixel_elem_4;
 
-char far *pixel_elem_b;   /* Buffer testuale per la funzione TEXT (40 car.),
+char *pixel_elem_b;   /* Buffer testuale per la funzione TEXT (40 car.),
                              il buffer contiene il testo, ma può contenere
                              l'id del pixel se nel testo viene inserito
                              il simbolo "%d", insieme ad eventuali caratteri.
                              Parametri per text, in ordine numerico da 0:
                              x, y, z, scalax, scalay, or.x, or.y */
 
-float far *docksite_x;   // Posizione dei siti di attracco per ogni pixeltype.
-float far *docksite_y;
-float far *docksite_z;
-float far *docksite_w;   // Larghezza e Profondità.
-float far *docksite_h;
+float *docksite_x;   // Posizione dei siti di attracco per ogni pixeltype.
+float *docksite_y;
+float *docksite_z;
+float *docksite_w;   // Larghezza e Profondità.
+float *docksite_h;
 
-float far *pixelmass; // Massa.
+float *pixelmass; // Massa.
 
-char far *subsignal; // Files per sottofondi audio.
+char *subsignal; // Files per sottofondi audio.
 
 /* Dati sugli oggetti. */
 
@@ -232,20 +232,20 @@ u16 objects = 0; // Nr. totale degli oggetti (non inizializzato).
 u16 _objects; // Variabile usata nei cicli come nr. totale di oggetti.
 
 ObjectTypeId  *objecttype;      // Tipo d'oggetto.
-double far *relative_x;      // Posizione X (relativa a quella del Pixel).
-double far *relative_y;      // Posizione Y (relativa a quella del Pixel).
-double far *relative_z;      // Posizione Z (relativa a quella del Pixel).
-double far *absolute_x;      // Posizione X (assoluta per Pixel = -1).
-double far *absolute_y;      // Posizione Y (assoluta per Pixel = -1).
-double far *absolute_z;      // Posizione Z (assoluta per Pixel = -1).
+double *relative_x;      // Posizione X (relativa a quella del Pixel).
+double *relative_y;      // Posizione Y (relativa a quella del Pixel).
+double *relative_z;      // Posizione Z (relativa a quella del Pixel).
+double *absolute_x;      // Posizione X (assoluta per Pixel = -1).
+double *absolute_y;      // Posizione Y (assoluta per Pixel = -1).
+double *absolute_z;      // Posizione Z (assoluta per Pixel = -1).
 PixelId  *object_location; // Pixel su cui si trova l'oggetto.
 
 /* IMPORTANTE: elevazione sulla superficie del pixel
                per ogni tipo di oggetto.
                I primi 3 sono già definiti a zerozerouno. */
 
-double far object_elevation[203] = { 0.01, 0.01, 0.01 };
-double far object_collyblockshifting[203];
+double object_elevation[203] = { 0.01, 0.01, 0.01 };
+double object_collyblockshifting[203];
 
 // Supporti vari.
 

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -259,7 +259,7 @@ double nav_y;
 double nav_z;
 
 double d; // Distanza generica.
-double k1; // Costanti ausiliarie.
+double k0, k1; // Costanti ausiliarie.
 int a, b, c; // Contatori ausiliari.
 
 int id; // 0, 1, 2 o 3. A seconda della distanza del pixel.

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -54,8 +54,8 @@ double tracking = 0; // Incremento a trackframe.
 u8 req_end_extra = 0; /* Flag: si richiede la fine dell'attività
                            extraveicolare ed il rientro nella nave? */
 
-i16 alfad = 0, betad = 0; // Velocità angolare su assi x ed y.
-i16 alfa90, beta90; // Supporti per alcuni calcoli.
+i16 v_alpha = 0, v_beta = 0; // Velocità angolare su assi x ed y.
+i16 alpha90, beta90; // Supporti per alcuni calcoli.
 
 u8 fid = 0; // Flag: Orientamento nella direzione opposta a quella corrente...
 u8 lead = 0; // Flag: Orientamento in direzione d'avanzamento...
@@ -239,10 +239,6 @@ double *absolute_x;      // Posizione X (assoluta per Pixel = -1).
 double *absolute_y;      // Posizione Y (assoluta per Pixel = -1).
 double *absolute_z;      // Posizione Z (assoluta per Pixel = -1).
 PixelId  *object_location; // Pixel su cui si trova l'oggetto.
-
-/* IMPORTANTE: elevazione sulla superficie del pixel
-               per ogni tipo di oggetto.
-               I primi 3 sono già definiti a zerozerouno. */
 
 double object_elevation[203] = { 0.01, 0.01, 0.01 };
 double object_collyblockshifting[203];

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -251,7 +251,7 @@ double object_collyblockshifting[203];
 
 PixelId pix = 0; // Pixel più vicino (ecoscandaglio, attracco automatico...)
 
-u8 extra = 0; // Flag: attività extraveicolare in corso?
+u8 EVA_in_progress = 0; // Flag: attività extraveicolare in corso?
 
 double r_x, r_y, r_z; // Posizioni relat. al pixel, per il fotogr. precedente.
 double dsx, dsy, dsz; // Posizioni reali del docksite del pixel-bersaglio.

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -472,7 +472,7 @@ void load_game (char i)
         std::fread (&cam_x, sizeof(f64), 1, fh);
         std::fread (&cam_y, sizeof(f64), 1, fh);
         std::fread (&cam_z, sizeof(f64), 1, fh);
-        std::fread (&alfa, sizeof(i16), 1, fh);
+        std::fread (&alpha, sizeof(i16), 1, fh);
         std::fread (&beta, sizeof(i16), 1, fh);
         std::fread (&nav_a, sizeof(i16), 1, fh);
         std::fread (&nav_b, sizeof(i16), 1, fh);
@@ -495,7 +495,7 @@ void load_game (char i)
         std::fread (&spd_y, sizeof(f64), 1, fh);
         std::fread (&spd_z, sizeof(f64), 1, fh);
         std::fread (&spd, sizeof(f64), 1, fh);
-        std::fread (&extra, 1, 1, fh);
+        std::fread (&EVA_in_progress, 1, 1, fh);
         std::fread (&rel_x, sizeof(f64), 1, fh);
         std::fread (&rel_y, sizeof(f64), 1, fh);
         std::fread (&rel_z, sizeof(f64), 1, fh);
@@ -550,7 +550,7 @@ void save_game (char i)
         std::fwrite (&cam_x, sizeof(f64), 1, fh);
         std::fwrite (&cam_y, sizeof(f64), 1, fh);
         std::fwrite (&cam_z, sizeof(f64), 1, fh);
-        std::fwrite (&alfa, sizeof(i16), 1, fh);
+        std::fwrite (&alpha, sizeof(i16), 1, fh);
         std::fwrite (&beta, sizeof(i16), 1, fh);
         std::fwrite (&nav_a, sizeof(i16), 1, fh);
         std::fwrite (&nav_b, sizeof(i16), 1, fh);
@@ -573,7 +573,7 @@ void save_game (char i)
         std::fwrite (&spd_y, sizeof(f64), 1, fh);
         std::fwrite (&spd_z, sizeof(f64), 1, fh);
         std::fwrite (&spd, sizeof(f64), 1, fh);
-        std::fwrite (&extra, 1, 1, fh);
+        std::fwrite (&EVA_in_progress, 1, 1, fh);
         std::fwrite (&rel_x, sizeof(f64), 1, fh);
         std::fwrite (&rel_y, sizeof(f64), 1, fh);
         std::fwrite (&rel_z, sizeof(f64), 1, fh);

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -231,7 +231,6 @@ void leggi_t_fino_a (FILE* fh, char codcar, int ptyp)
     if (eol) {
         std::fclose (fh);
         //dsp_driver_off ();
-        _80_25_C();
         cerr << "Parameter not found\nElement "
             << (pixeltype_elements[static_cast<int>(loaded_pixeltypes)]+1)
             << " of pixel type " << ptyp << "." << endl;
@@ -285,7 +284,6 @@ void load_pixels_def(void) {
     if (fh) {
         if (!trova_id (fh, "SEED")) {
             std::fclose (fh);
-            _80_25_C();
             cerr << "Missing command in PIXELS.DEF: SEED = n;"
                  << "\n<n> must be a number between 0 and 65535." << endl;
             throw 3;
@@ -296,7 +294,6 @@ void load_pixels_def(void) {
         std::fseek (fh, 0, SEEK_SET);
         if (!trova_id (fh, "AUTHOR")) {
             std::fclose (fh);
-            _80_25_C();
             cerr << "Missing command in PIXELS.DEF: AUTHOR = AUTHOR_NAME;" << endl;
             throw 4;
         }
@@ -310,7 +307,6 @@ void load_pixels_def(void) {
             existent_pixeltypes++;
             ptyp++; sprintf (t, "TYPE %d;\r\n", ptyp);
             if (ptyp>FRONTIER_M1) {
-                _80_25_C();
                 cout << "Too many pixels.\nIt will only load "
                      << FRONTIER << " pixels (from type 0 to type "
                      << FRONTIER_M1 << ")." << endl;
@@ -323,7 +319,6 @@ void load_pixels_def(void) {
             existent_objecttypes++;
             ptyp++; sprintf (t, "MODEL %d;\r\n", ptyp);
             if (ptyp>FRONTIER_COMPL_M1) {
-                _80_25_C();
                 cout << "Too many object models.\nIt will only load "
                     << FRONTIER_COMPL << " objects (from model 0 to model "
                     << FRONTIER_COMPL_M1 << ")." << endl;

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -477,10 +477,10 @@ void load_game (char i)
         std::fread (&reset_trackframe, 1, 1, fh);
         std::fread (&tracking, sizeof(f64), 1, fh);
         std::fread (&req_end_extra, 1, 1, fh);
-        std::fread (&alfad, sizeof(i16), 1, fh);
-        std::fread (&betad, sizeof(i16), 1, fh);
+        std::fread (&v_alpha, sizeof(i16), 1, fh);
+        std::fread (&v_beta, sizeof(i16), 1, fh);
         std::fread (&pix, sizeof(i16), 1, fh);
-        std::fread (&alfa90, sizeof(i16), 1, fh);
+        std::fread (&alpha90, sizeof(i16), 1, fh);
         std::fread (&beta90, sizeof(i16), 1, fh);
         std::fread (&fid, 1, 1, fh);
         std::fread (&lead, 1, 1, fh);
@@ -555,10 +555,10 @@ void save_game (char i)
         std::fwrite (&reset_trackframe, sizeof(u8), 1, fh);
         std::fwrite (&tracking, sizeof(f64), 1, fh);
         std::fwrite (&req_end_extra, sizeof(u8), 1, fh);
-        std::fwrite (&alfad, sizeof(i16), 1, fh);
-        std::fwrite (&betad, sizeof(i16), 1, fh);
+        std::fwrite (&v_alpha, sizeof(i16), 1, fh);
+        std::fwrite (&v_beta, sizeof(i16), 1, fh);
         std::fwrite (&pix, sizeof(PixelId), 1, fh);
-        std::fwrite (&alfa90, sizeof(i16), 1, fh);
+        std::fwrite (&alpha90, sizeof(i16), 1, fh);
         std::fwrite (&beta90, sizeof(i16), 1, fh);
         std::fwrite (&fid, 1, 1, fh);
         std::fwrite (&lead, 1, 1, fh);

--- a/source/text3d.cpp
+++ b/source/text3d.cpp
@@ -95,7 +95,7 @@ char symbol[65][41] = {
 4, -1, -2,  1, -1,  1, -1,  0, -1,  0, -1, -1, -1, -1, -1, -1, -2,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 };
 
 void Txt (const char * testo, double x, double y, double z,
-	  double scala_x, double scala_y, int alfa, int beta)
+	  double scala_x, double scala_y, int alpha, int beta)
 {
 	double fxx=0, fyy=0, pxx=0, pyy=0;
 	double lsx=0, lsy=0, lsz=0;
@@ -142,21 +142,21 @@ void Txt (const char * testo, double x, double y, double z,
 		for (l=0; l<symbol[t][0]; l++) {
 			fxx = symbol[t][f+0]*scala_x;
 			fyy = symbol[t][f+1]*scala_y;
-			if (fxx==pxx&&fyy==pyy) {
+			if (fxx==pxx && fyy==pyy) {
 				sx = lsx;
 				sy = lsy;
 				sz = lsz;
 			}
 			else {
-				z2 = fyy * tsin[alfa];
-				sy = fyy * tcos[alfa] + y;
+				z2 = fyy * tsin[alpha];
+				sy = fyy * tcos[alpha] + y;
 				sz = z2  * tcos[beta] - fxx * tsin[beta] + z;
 				sx = fxx * tcos[beta] + z2  * tsin[beta] + x;
 			}
 			pxx = symbol[t][f+2]*scala_x;
 			pyy = symbol[t][f+3]*scala_y;
-			z2  = pyy * tsin[alfa];
-			lsy = pyy * tcos[alfa] + y;
+			z2  = pyy * tsin[alpha];
+			lsy = pyy * tcos[alpha] + y;
 			lsz = z2  * tcos[beta] - pxx * tsin[beta] + z;
 			lsx = pxx * tcos[beta] + z2  * tsin[beta] + x;
 			Line3D (sx, sy, sz, lsx, lsy, lsz);


### PR DESCRIPTION
This pull request is a bit of a mixed bag, a collection of changes I did that seemed for the better. Sorry if it's not focused on one issue, it's my first pull request and I'll get better.

The important changes are:
- I created `draw.h` and `draw.cpp` to hold functions that were previously just lines of code scattered about `cryxtels.cpp`. They are given simple, well defined tasks and named accordingly:
   - `draw_line_relative` corresponds to the old function `n` and draws a line between two 3D points whose coordinates are given relative to the current player's frame of reference, `nav` (which includes position, `nav_x`,`_y`,`_z` and rotation, `nav_a` and `_b`);
   - `draw_text_relative` corresponds to `nTxt`;
   - `draw_rect_relative` corresponds to `nrect`;
   - The other functions are pretty self-explainatory and serve to draw various elements of the spaceship or UI.
- I did some unit conversions and found out that the speed indicator was wrong (also tested it by timing the ship with my phone's chronometer).
- The algorithm for the Spiral primitive produced spirals that were made of disconnected segments; a small fix produced smooth, unbroken spirals
- There was a typo in the code for the Wave primitive that produced "squashed" waves when these were oriented along the XZ plane. There aren't any pixels in the original PIXELS.DEF that use waves like this, I only found this bug while trying out my custom "Beach" pixel ;)