### PR TITLE
Fix and optimize object taking routine

### DIFF
--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1062,7 +1062,9 @@ bool main_loop() {
         if (taking&&!EVA_in_progress) {
             kk = 500;
             obj = -1;
-            for (u16 o=_objects-1; o>=0; o--) {
+            // cycle through objects in reverse order
+            // (stopping as soon as `o` underflows)
+            for (u16 o = _objects-1; o < _objects; o--) {
                 if (object_location[o]==-1) {
                     _x = absolute_x[o] - cam_x;
                     _y = absolute_y[o] - cam_y;

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1060,7 +1060,7 @@ bool main_loop() {
 
         // handle object pick up request while flying
         if (taking&&!EVA_in_progress) {
-            kk = 500;
+            kk = 500 * 500;
             obj = -1;
             // cycle through objects in reverse order
             // (stopping as soon as `o` underflows)
@@ -1069,8 +1069,8 @@ bool main_loop() {
                     _x = absolute_x[o] - cam_x;
                     _y = absolute_y[o] - cam_y;
                     _z = absolute_z[o] - cam_z;
-                    d = sqrt (_x*_x+_y*_y+_z*_z);
-                    if (d<kk) {
+                    d = _x*_x+_y*_y+_z*_z;
+                    if (d < kk) {
                         kk = d;
                         obj = o;
                     }

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -2399,21 +2399,23 @@ trovato:while (nr_elem<pixeltype_elements[iii]) {
 
         // handle object pick up request while in a pixel
         if (taking) {
-                kk = 40;
-                for (o=_objects-1; o>=0; o--) {
-                        // ctrlkeys[0]&64 is Caps Lock
-                        if (object_location[o]==nopix&&(pixelmass[objecttype[o]+FRONTIER_M3]<100||(ctrlkeys[0]&64))) {
-                                _x = (relative_x[o] + pixel_xdisloc[nopix]) - (cam_xt - 10 * tsin[beta] * tcos[alpha]);
-                                _y = (relative_y[o] + pixel_ydisloc[nopix] - object_elevation[objecttype[o]]) - (cam_yt + 10 * tsin[alpha]);
-                                _z = (relative_z[o] + pixel_zdisloc[nopix]) - (cam_zt + 10 * tcos[beta] * tcos[alpha]);
-                                _y /= 3;
-                                d = sqrt (_x*_x+_y*_y+_z*_z);
-                                if (d<kk) {
-                                        obj = o;
-                                        kk = d;
-                                }
-                        }
+            kk = 40 * 40;
+            // cycle through objects in reverse order
+            // (stopping as soon as `o` underflows)
+            for (u16 o = _objects-1; o < _objects; o--) {
+                // ctrlkeys[0]&64 is Caps Lock
+                if (object_location[o]==nopix&&(pixelmass[objecttype[o]+FRONTIER_M3]<100||(ctrlkeys[0]&64))) {
+                    _x = (relative_x[o] + pixel_xdisloc[nopix]) - (cam_xt - 10 * tsin[beta] * tcos[alpha]);
+                    _y = (relative_y[o] + pixel_ydisloc[nopix] - object_elevation[objecttype[o]]) - (cam_yt + 10 * tsin[alpha]);
+                    _z = (relative_z[o] + pixel_zdisloc[nopix]) - (cam_zt + 10 * tcos[beta] * tcos[alpha]);
+                    _y /= 3;
+                    d = _x*_x + _y*_y + _z*_z;
+                    if (d < kk) {
+                        obj = o;
+                        kk = d;
+                    }
                 }
+            }
         }
 }
 


### PR DESCRIPTION
Resolves #24. I also added a small optimization to the distance calculation.

- Fix infinite loop when the player cannot pick up any object.
   - When all objects are too far away, the for loop would never end because the index variable is unsigned. Changing the loop condition breaks the infinite loop.
- Optimize object proximity check for pick-up, by comparing square distances instead of applying a square root.
