### PR TITLE
Add a timestamp to the snapshot's filename

### DIFF
--- a/readme new.txt
+++ b/readme new.txt
@@ -32,7 +32,7 @@ In either mode:
     F3 : Enter / leave The Fly.
     F4 : Dock / Undock.
     F5 : Point towards Sunny ; while carrying a pixel, switch the pixel being carried to the next one.
-    F6 : Take a snapshot and save it with the name "SNAP.BMP".
+    F6 : Take a snapshot and save it with the name "SNAP <date> <time>.BMP".
     F7 : Toggle text typing mode, so that you can type in notepad objects.
     TAB : Toggle capability of climbing onto objects.
     M : Toggle between Keyboard mode and Mouse mode.

--- a/readme new.txt
+++ b/readme new.txt
@@ -32,7 +32,7 @@ In either mode:
     F3 : Enter / leave The Fly.
     F4 : Dock / Undock.
     F5 : Point towards Sunny ; while carrying a pixel, switch the pixel being carried to the next one.
-    F6 : Take a snapshot and save it with the name "SNAP <date> <time>.BMP".
+    F6 : Take a snapshot and save it with the name "SNAP_<date>_<time>.BMP".
     F7 : Toggle text typing mode, so that you can type in notepad objects.
     TAB : Toggle capability of climbing onto objects.
     M : Toggle between Keyboard mode and Mouse mode.

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -166,13 +166,13 @@ void toggle_fullscreen (void) {
 
 void snapshot (void)
 {
-    const size_t fmtlen = sizeof("SNAP 2025-11-25 132109.bmp");
+    const size_t fmtlen = sizeof("SNAP_2025-11-25_132109.BMP");
     char datetime[fmtlen + 1];
     char filename[fmtlen + 1];
 
     time_t now; std::time(&now);
-    strftime(datetime, fmtlen, "%Y-%m-%d %H%M%S", std::localtime(&now));
-    sprintf(filename, "SNAP %s.bmp", datetime);
+    strftime(datetime, fmtlen, "%Y-%m-%d_%H%M%S", std::localtime(&now));
+    sprintf(filename, "SNAP_%s.BMP", datetime);
     
     SDL_SaveBMP(p_surface_32, filename);
 }

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -18,6 +18,7 @@
 #include "fast3d.h"
 
 #include <cmath>
+#include <ctime>
 #include <iostream>
 #include <cstdlib>
 #include <cstring>
@@ -165,7 +166,15 @@ void toggle_fullscreen (void) {
 
 void snapshot (void)
 {
-    SDL_SaveBMP(p_surface_32, "SNAP.bmp");
+    const size_t fmtlen = sizeof("SNAP 2025-11-25 132109.bmp");
+    char datetime[fmtlen + 1];
+    char filename[fmtlen + 1];
+
+    time_t now; std::time(&now);
+    strftime(datetime, fmtlen, "%Y-%m-%d %H%M%S", std::localtime(&now));
+    sprintf(filename, "SNAP %s.bmp", datetime);
+    
+    SDL_SaveBMP(p_surface_32, filename);
 }
 
 void Render (void)


### PR DESCRIPTION
Screenshots have always been saved simply as `SNAP.BMP`. This may result in a previously taken screenshot being overwritten. This is very inconvenient if more than one screenshot needs to be taken in a single game session.

This PR adds a timestamp to the end of each screenshot's filename. The format is e.g. `SNAP_2025-11-25_132109.BMP`, which has the same date format of ISO 8601 while representing time in an unbroken string of digits. This is a common convention to use since colons aren't available as filename characters and instant readability isn't much of a concern for the exact time a screenshot was taken (the date is more important, generally). It's very similar to the format Windows 11 uses for its screenshot tool, only with underscores instead of whitespace.

By adding a timestamp, the user can now take screenshots without the risk of overwriting an older one, as long as no more than one screenshot is taken within a one-second interval.