### PR TITLE
Fix setting fullscreen mode on some platforms

### DIFF
--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -160,8 +160,8 @@ void darken_once (u8 inc) {
 }
 
 void toggle_fullscreen (void) {
-    auto flags = SDL_GetWindowFlags(p_window);
-    SDL_SetWindowFullscreen(p_window, flags ^ SDL_WINDOW_FULLSCREEN_DESKTOP);
+    auto fullscreen_flags = SDL_GetWindowFlags(p_window) & SDL_WINDOW_FULLSCREEN_DESKTOP; 
+    SDL_SetWindowFullscreen(p_window, fullscreen_flags ^ SDL_WINDOW_FULLSCREEN_DESKTOP);
 }
 
 void snapshot (void)


### PR DESCRIPTION
I found and fixed another interesting bug, reproducible on my Linux machine with sdl2-compat 2.32.56-2 and sdl3 3.2.22-1, in which I could not enter fullscreen mode. Apparently including other unrelated Window flags in a call to function `SDL_SetWindowFullScreen` might make the operation do nothing, instead of the intended outcome of entering fullscreen.
