### PR TITLE
Adjust trigger for illusory space redraw

### DIFF
--- a/readme new.txt
+++ b/readme new.txt
@@ -39,7 +39,7 @@ In either mode:
     X : Show/hide The Fly.
     I : Toggle direction indicators.
     E : Toggle Echo sonar.
-    Alt gr (right alt) : Keep it pressed for a hallucinating blur effect.
+    Alt gr (right alt) : Keep it pressed for illusory space redraw, a hallucinating blur effect.
     Left/Right/Up/Down : Move the cursor when writing to a notepad.
    
 __________________

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -778,8 +778,10 @@ bool main_loop() {
             cam_z = dsz + rel_z;
         }
 
-        // Sezione ridisegno spazio illusorio.
-        /// Create hallucinating effect.
+        // Illusory space redraw section.
+        // Create a hallucinating effect
+        // by darkening the video buffer
+        // instead of clearing it.
         if (ctrlkeys[0]&32) { // ctrlkeys[0]&32 is right alt
             darken_once();
                         /*

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -178,8 +178,8 @@ void update_ctrlkeys()
     if (r & KMOD_LALT)
         ctrlkeys[0] |= 16;
 
-    // relocating this to right alt instead of left alt
-    if (r & KMOD_RALT)
+    // recognize right alt and mode modifier
+    if ((r & KMOD_RALT) || (r & KMOD_MODE))
         ctrlkeys[0] |= 32;
 
     if (r & KMOD_CAPS)


### PR DESCRIPTION
This effect is not very known and was not even documented, but it was available in the Italian version by activating Num lock, and it was already ported here. I did a rough translation of the effect's name, originally _"ridisegno spazio illusorio"_, to _"illusory space redraw"_. It its a hallucinating effect where the background is only darkened instead of cleared.

Anyways, this effect was currently not working on my machine, so I investigated the issue and found that SDL was enabling the KMOD_MODE keyboard modifier when holding the Alt Gr key instead of right alt, for some reason.

### Known caveats

Maybe I should try to remap it again to num lock? The thing is, I'm finding that most key modifiers are not being properly mapped on my machine, so I cannot be sure that this behavior will be consistent.

