### PR TITLE
Change video surfaces and textures to 8-bit indexed, add configurable scaling mode

### DIFF
--- a/bin/SETTINGS.INI
+++ b/bin/SETTINGS.INI
@@ -11,9 +11,14 @@
 width = 320
 height = 200
 
-# size of each pixel
+# size of each pixel in windowed mode
 scale_x = 2.0
 scale_y = 2.0
+
+# the window's pixel scale algorithm:
+# - nearest (default)
+# - linear
+scale_mode = nearest
 
 # framerate for the intro sequence
 framerate_intro = 20

--- a/include/conf.h
+++ b/include/conf.h
@@ -27,6 +27,7 @@
 
 #define CONFIG_FILE_NAME "SETTINGS.INI"
 
+/** Game configuration (from SETTINGS.INI) */
 typedef struct conf {
 
     // --- render group ---
@@ -43,6 +44,7 @@ typedef struct conf {
     float window_scale_y;
     u32 window_width; /// == render_width * window_scale_x
     u32 window_height; /// == render_height * window_scale_y
+    SDL_ScaleMode scale_mode;
 
     // --- cosm group ---
 

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -31,14 +31,6 @@ extern std::unique_ptr<u8[]> video_buffer;
 /// Global pointer to the main window
 extern SDL_Window * p_window;
 
-/// Some old adapters.
-//unsigned char * adaptor = (unsigned char *) 0xA0000000;
-//unsigned char * adapted = (unsigned char *) 0x80000000;
-//unsigned char * fake_adaptor = (unsigned char *) 0x80000000;
-
-/// This is the main palette.
-//extern unsigned char tmppal[768];
-
 /// Trigonometric tables, allocated dynamically and written in runtime.
 extern float *tcos, *tsin;
 extern float *tcosx, *tsinx;
@@ -77,10 +69,11 @@ void Render (void);
 /// Take a snapshot to a BMP
 void snapshot (void);
 
-/// Create a palette table based on new_palette.
-void tavola_colori (const u8 *new_palette,
-		    unsigned int starting_color, unsigned int nr_colors,
-		    i8 red_filter, i8 green_filter, i8 blue_filter);
+/// Update the pallette with the given saturation of yellow
+/// (for proximity to Sunny)
+///
+/// \param saturation the amount of yellow, between 0 and 255
+void tinte(u8 saturation);
 
 /// Copy a graphical page
 // Ultraveloce copia di pagina grafica.

--- a/include/fast3d.h
+++ b/include/fast3d.h
@@ -73,7 +73,7 @@ void snapshot (void);
 /// (for proximity to Sunny)
 ///
 /// \param saturation the amount of yellow, between 0 and 255
-void tinte(u8 saturation);
+void update_palette(u8 saturation);
 
 /// Copy a graphical page
 // Ultraveloce copia di pagina grafica.

--- a/source/conf.cpp
+++ b/source/conf.cpp
@@ -46,6 +46,17 @@ Config load_config(const std::string& fpath) {
     config.window_width = config.render_width * config.window_scale_x;
     config.window_height = config.render_height * config.window_scale_y;
 
+    SDL_ScaleMode mode = SDL_SCALEMODE_NEAREST;
+    auto scale = ini["render"]["scale_mode"] | "nearest";
+    if (scale.empty() || scale == "nearest") {
+        mode = SDL_SCALEMODE_NEAREST;
+    } else if (scale == "linear") {
+        mode = SDL_SCALEMODE_LINEAR;
+    } else {
+        std::cerr << "Invalid setting `render.scale_mode`: must be one of \"nearest\" or \"linear\"" << std::endl;
+    }
+    config.scale_mode = mode;
+
     config.cosm_pixels = ini["cosm"]["num_pixels"] | 250;
     config.cosm_objects = ini["cosm"]["num_objects"] | 250;
     config.situation_file = ini["cosm"]["situation_file"] | "";

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -189,9 +189,6 @@ void lead_on ();
 /// Point towards Sunny
 void orig_on ();
 
-/// Generate the color palette
-void tinte (u8 satu);
-
 /// Explode
 void scoppia (int nr_ogg, double potenza, int var);
 
@@ -232,7 +229,7 @@ int main(int argc, char** argv)
 
         // set the display
         init_video();
-        tinte (0);
+        update_palette (0);
 
         // initialize audio device (unless it was disabled via settings)
         if (audioEnabled) {
@@ -441,7 +438,7 @@ bool main_loop() {
                     case SDLK_RETURN:
                         if (ctrlkeys[0]&16) {
                             toggle_fullscreen();
-                            tinte(0);
+                            update_palette(0);
                         }
                         break;
                     case keymap_up:
@@ -721,13 +718,13 @@ bool main_loop() {
         if (dsol<15000) {
             // adjusted from (63-dsol/240)
             // to account for new sample value range (0..256)
-            tinte (static_cast<unsigned char>(255 - dsol / 60.));
+            update_palette (static_cast<unsigned char>(255 - dsol / 60.));
             yel = true;
         }
         else {
             if (yel) {
                 // reset to no yellow if last game frame had some yellow
-                tinte (0);
+                update_palette (0);
                 yel = false;
             }
         }

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1424,32 +1424,6 @@ inline bool allocation_farm()
     return true;
 }
 
-void tinte (unsigned char satu)
-{
-    constexpr unsigned char K = 255;
-    constexpr unsigned int GRAD_COUNT_1 = 16 * 3;
-    constexpr unsigned int GRAD_COUNT_2 = 16 * 3;
-
-    constexpr float F1 = 256.f / GRAD_COUNT_1;
-    constexpr float F2 = 256.f / GRAD_COUNT_2;
-
-    unsigned int i;
-    for (i=0; i < 768; i++) {
-        buffer[i] = K;
-    }
-    for (i=0; i < GRAD_COUNT_1; i += 3) {
-        buffer[i] = buffer[i + 1] = satu;
-        buffer[i + 2] = static_cast<float>(i) * F1;
-    }
-    for (i=0; i < GRAD_COUNT_2; i += 3) {
-        unsigned int v = static_cast<float>(i) * F2 + satu;
-        if (v > K) v = K;
-        buffer[i + GRAD_COUNT_1] = v;
-        buffer[i + GRAD_COUNT_1 + 1] = v;
-    }
-    tavola_colori (buffer, 0, 256, 63, 63, 63);
-}
-
 /// redefinition of random(int),
 /// which probably became deprecated.
 /// Generates a random number between 0 and max_num-1

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -72,6 +72,7 @@ static int zbasex, zbasey;
 static int nav_zbasex, nav_zbasey;
 static int lowerbound_y, upperbound_y;
 static int lowerbound_x, upperbound_x;
+static SDL_ScaleMode scale_mode;
 
 static void read_config(void) {
     const Config& config = get_config();
@@ -81,6 +82,7 @@ static void read_config(void) {
     framebuffer_size = width * height;
     window_width = config.window_width;
     window_height = config.window_height;
+    scale_mode = config.scale_mode;
 
     x_center = width / 2;
     y_center = height / 2;
@@ -121,8 +123,10 @@ void init_video () {
 
     p_texture = SDL_CreateTexture(p_renderer, SDL_PIXELFORMAT_INDEX8,
                                   SDL_TEXTUREACCESS_STREAMING, width, height);
-
+    // use the same palette for both surface and texture
     SDL_SetTexturePalette(p_texture, p_palette);
+    // set window scaling interpolation
+    SDL_SetTextureScaleMode(p_texture, scale_mode);
     SDL_SetWindowMinimumSize(p_window, width, height);
 }
 

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -28,11 +28,10 @@
 #include "conf.h"
 
 // Variables!
-//SDL_Surface * p_surface = nullptr;
 std::unique_ptr<u8[]> video_buffer;
 
 SDL_Window * p_window = nullptr;
-SDL_Surface * p_surface_32 = nullptr;
+SDL_Surface * p_surface = nullptr;
 SDL_Surface * p_surface_scaled = nullptr;
 SDL_Renderer * p_renderer = nullptr;
 SDL_Texture * p_texture = nullptr;
@@ -59,11 +58,11 @@ const int lwy = 3;
 double uneg = 1;
 double mindiff = 0.01;
 
-/// New Palette definition
-u8 tmppal[256 * 4]; // 256*4 bytes (RGBU)
+/// Newer Palette definition
+SDL_Palette* p_palette;
 
-// Old Palette definition
-//unsigned char tmppal[768]; // 256*3 bytes (RGB)
+/// temporary space for palette colors
+u8 tmppal[256 * 4]; // 256 RGBX colors
 
 static u32 width, height;
 static u32 framebuffer_size;
@@ -111,8 +110,10 @@ void init_video () {
     video_buffer.reset(new unsigned char[framebuffer_size]);
     memset(&video_buffer[0], 0, framebuffer_size);
 
-    p_surface_32 = SDL_CreateSurface(width, height, SDL_PIXELFORMAT_RGBX32);
-    if (p_surface_32 == nullptr) throw sdl_exception();
+    p_surface = SDL_CreateSurface(width, height, SDL_PIXELFORMAT_INDEX8);
+    if (p_surface == nullptr) throw sdl_exception();
+
+    p_palette = SDL_CreateSurfacePalette(p_surface);
 
     p_window = SDL_CreateWindow("Crystal Pixels",
             window_width, window_height, SDL_WINDOW_RESIZABLE);
@@ -120,8 +121,10 @@ void init_video () {
 
     p_renderer = SDL_CreateRenderer(p_window, nullptr);
 
-    p_texture = SDL_CreateTexture(p_renderer, SDL_PIXELFORMAT_RGBX32,
-                                  SDL_TEXTUREACCESS_STREAMING, width,height);
+    p_texture = SDL_CreateTexture(p_renderer, SDL_PIXELFORMAT_INDEX8,
+                                  SDL_TEXTUREACCESS_STREAMING, width, height);
+
+    SDL_SetTexturePalette(p_texture, p_palette);
 
     //p_surface_scaled = SDL_GetWindowSurface(p_window);
     SDL_SetWindowMinimumSize(p_window, width, height);
@@ -158,77 +161,89 @@ void snapshot (void)
     strftime(datetime, fmtlen, "%Y-%m-%d_%H%M%S", std::localtime(&now));
     sprintf(filename, "SNAP_%s.BMP", datetime);
     
-    SDL_SaveBMP(p_surface_32, filename);
+    SDL_SaveBMP(p_surface, filename);
 }
 
 void Render (void)
 {
-    using namespace std;
 
     // convert indexed 8-bit to RGBA 32-bit colors
-    SDL_LockTexture(p_texture, nullptr, &p_surface_32->pixels, &p_surface_32->pitch);
-    // paint into surface pixels
-    unsigned int rpos = 0;
-    unsigned int rpos_32 = 0;
-    unsigned char* p_orig = &video_buffer[0];
-    unsigned int* p_dest = static_cast<unsigned int*>(p_surface_32->pixels);
-    for (unsigned int y = 0 ; y < height ; y++) {
-        for (unsigned int x = 0 ; x < width ; x++) {
-            auto pixel = p_orig[rpos + x];
-            unsigned int c = tmppal[pixel * 4]
-                | (tmppal[pixel * 4 + 1] << 8)
-                | (tmppal[pixel * 4 + 2] << 16)
-                | (tmppal[pixel * 4 + 3] << 24);
-            p_dest[rpos_32 + x] = c;
-        }
-        rpos += width;
-        rpos_32 += (p_surface_32->pitch >> 2);
-    }
+    SDL_LockTexture(p_texture, nullptr, &p_surface->pixels, &p_surface->pitch);
+
+    // copy directly from the buffer
+    memcpy(p_surface->pixels, &video_buffer[0], width * height);
+
+    SDL_UpdateTexture(p_texture, nullptr, &video_buffer[0], width);
     SDL_UnlockTexture(p_texture);
     SDL_RenderTexture(p_renderer, p_texture, nullptr, nullptr);
     SDL_RenderPresent(p_renderer);
 }
 
+/// Create a palette table based on new_palette, with an optional filtering
 void tavola_colori (const u8 *nuova_tavolozza,
             unsigned int colore_di_partenza, unsigned int nr_colori,
             i8 filtro_rosso, i8 filtro_verde, i8 filtro_blu)
 {
-    constexpr unsigned int K_FILTER = 63; // original is 63
-    unsigned int c, cc = 0;
-    nr_colori *= 4; // using new padding in palette table
-    colore_di_partenza *= 4; // new padding
+    constexpr unsigned int K_FILTER = 63; // maximum post-filter value
 
-    int pad = 3;
-    c = colore_di_partenza;
-    while (c < nr_colori-colore_di_partenza) {
-        tmppal[c] = nuova_tavolozza[cc];
-        cc++;
-        c++;
-        if (--pad == 0) {
-            tmppal[c] = 0;
-            c++;
-            pad = 3;
-        }
+    // first copy palette
+    SDL_SetPaletteColors(p_palette, reinterpret_cast<const SDL_Color*>(nuova_tavolozza), 0, nr_colori);
+
+    // then apply the filter if necessary
+
+    // (pinky-promise that the filter works,
+    // it's just that it's not worth doing so many calculations
+    // if the outcome is the same)
+    if (filtro_rosso == 63 && filtro_verde == 63 && filtro_blu == 63) {
+        return;
     }
 
-    c = colore_di_partenza;
-    while (c<nr_colori+colore_di_partenza) {
-        u16 temp = tmppal[c];
-        temp *= (u8)filtro_rosso;
-        temp /= K_FILTER;
-        tmppal[c] = temp;
-        c++;
-        temp = tmppal[c];
-        temp *= (u8)filtro_verde;
-        temp /= K_FILTER;
-        tmppal[c] = temp;
-        c++;
-        temp = tmppal[c];
-        temp *= (u8)filtro_blu;
-        temp /= K_FILTER;
-        tmppal[c] = temp;
-        c+=2;
+    for (unsigned int c = colore_di_partenza; c < static_cast<unsigned int>(p_palette->ncolors); c++) {
+        auto& color = p_palette->colors[c];
+        // red
+        u16 temp = color.r * static_cast<u8>(filtro_rosso) / K_FILTER;
+        color.r = static_cast<u8>(temp);
+        // green
+        temp = color.g * static_cast<u8>(filtro_verde) / K_FILTER;
+        color.g = static_cast<u8>(temp);
+        // blue
+        temp = color.b * static_cast<u8>(filtro_blu) / K_FILTER;
+        color.b = static_cast<u8>(temp);
     }
+}
+
+void tinte (unsigned char satu)
+{
+    constexpr u8 K = 255;
+    constexpr unsigned int GRAD_COUNT_1 = 16 * 4;
+    constexpr unsigned int GRAD_COUNT_2 = 16 * 4;
+
+    constexpr float F1 = 256.f / GRAD_COUNT_1;
+    constexpr float F2 = 256.f / GRAD_COUNT_2;
+
+    unsigned int i;
+    // gradient 1: black to blue
+    for (i = 0; i < GRAD_COUNT_1; i += 4) {
+        tmppal[i] = tmppal[i + 1] = satu;
+        tmppal[i + 2] = static_cast<float>(i) * F1;
+        tmppal[i + 3] = 0;
+    }
+    // gradient 2: maximum blue to white
+    for (i = 0; i < GRAD_COUNT_2; i += 4) {
+        unsigned int v = static_cast<float>(i) * F2 + satu;
+        if (v > K) v = K;
+        tmppal[i + GRAD_COUNT_1] = v;
+        tmppal[i + GRAD_COUNT_1 + 1] = v;
+        // maximum blue
+        tmppal[i + GRAD_COUNT_1 + 2] = 255;
+        tmppal[i + GRAD_COUNT_1 + 3] = 0;
+    }
+    // the rest of the palette is white
+    for (i = GRAD_COUNT_1 + GRAD_COUNT_2; i < 256 * 4; i++) {
+        tmppal[i] = K;
+    }
+
+    tavola_colori (tmppal, 0, 256, 63, 63, 63);
 }
 
 // This function is unsafe and should be removed

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -156,21 +156,18 @@ void snapshot (void)
     time_t now; std::time(&now);
     strftime(datetime, fmtlen, "%Y-%m-%d_%H%M%S", std::localtime(&now));
     sprintf(filename, "SNAP_%s.BMP", datetime);
-    
+
+    SDL_LockSurface(p_surface);
+    // copy to the surface
+    memcpy(p_surface->pixels, &video_buffer[0], width * height);
+    SDL_UnlockSurface(p_surface);
+
     SDL_SaveBMP(p_surface, filename);
 }
 
 void Render (void)
 {
-
-    // convert indexed 8-bit to RGBA 32-bit colors
-    SDL_LockTexture(p_texture, nullptr, &p_surface->pixels, &p_surface->pitch);
-
-    // copy directly from the buffer
-    memcpy(p_surface->pixels, &video_buffer[0], width * height);
-
     SDL_UpdateTexture(p_texture, nullptr, &video_buffer[0], width);
-    SDL_UnlockTexture(p_texture);
     SDL_RenderTexture(p_renderer, p_texture, nullptr, nullptr);
     SDL_RenderPresent(p_renderer);
 }

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -201,13 +201,13 @@ void tavola_colori (const u8 *nuova_tavolozza,
     for (unsigned int c = colore_di_partenza; c < static_cast<unsigned int>(p_palette->ncolors); c++) {
         auto& color = p_palette->colors[c];
         // red
-        u16 temp = color.r * static_cast<u8>(filtro_rosso) / K_FILTER;
+        u16 temp = color.r * static_cast<u16>(filtro_rosso) / K_FILTER;
         color.r = static_cast<u8>(temp);
         // green
-        temp = color.g * static_cast<u8>(filtro_verde) / K_FILTER;
+        temp = color.g * static_cast<u16>(filtro_verde) / K_FILTER;
         color.g = static_cast<u8>(temp);
         // blue
-        temp = color.b * static_cast<u8>(filtro_blu) / K_FILTER;
+        temp = color.b * static_cast<u16>(filtro_blu) / K_FILTER;
         color.b = static_cast<u8>(temp);
     }
 }

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -32,7 +32,6 @@ std::unique_ptr<u8[]> video_buffer;
 
 SDL_Window * p_window = nullptr;
 SDL_Surface * p_surface = nullptr;
-SDL_Surface * p_surface_scaled = nullptr;
 SDL_Renderer * p_renderer = nullptr;
 SDL_Texture * p_texture = nullptr;
 
@@ -115,18 +114,15 @@ void init_video () {
 
     p_palette = SDL_CreateSurfacePalette(p_surface);
 
-    p_window = SDL_CreateWindow("Crystal Pixels",
-            window_width, window_height, SDL_WINDOW_RESIZABLE);
+    SDL_CreateWindowAndRenderer("Crystal Pixels",
+            window_width, window_height, SDL_WINDOW_RESIZABLE,
+            &p_window, &p_renderer);
     if (p_window == nullptr) throw sdl_exception();
-
-    p_renderer = SDL_CreateRenderer(p_window, nullptr);
 
     p_texture = SDL_CreateTexture(p_renderer, SDL_PIXELFORMAT_INDEX8,
                                   SDL_TEXTUREACCESS_STREAMING, width, height);
 
     SDL_SetTexturePalette(p_texture, p_palette);
-
-    //p_surface_scaled = SDL_GetWindowSurface(p_window);
     SDL_SetWindowMinimumSize(p_window, width, height);
 }
 

--- a/source/fast3d.cpp
+++ b/source/fast3d.cpp
@@ -212,7 +212,7 @@ void tavola_colori (const u8 *nuova_tavolozza,
     }
 }
 
-void tinte (unsigned char satu)
+void update_palette (u8 satu)
 {
     constexpr u8 K = 255;
     constexpr unsigned int GRAD_COUNT_1 = 16 * 4;


### PR DESCRIPTION
Cuts the need for a 32-bit video buffer, potentially improving memory usage and performance.

### Summary

- change pixel format of main surface and texture to SDL_PIXELFORMAT_INDEX8
   - create and use the same color palette for both
- move tinte function to fast3d module
- refactor and optimize tavola_colori
- optimize rendering by skipping the copy to the surface (copy to texture directly) and only using it to take screenshots
- make target texture scaling mode configurable through SETTINGS.INI ("nearest" or "linear", default is "nearest") 
