### PR TITLE
Improve the ship's attitude controls

### DIFF
--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -68,6 +68,14 @@ static void read_config(void) {
     audioEnabled = config.audio_enabled;
 }
 
+inline i16 angle(i16 x) {
+    return x - std::floor((float)x/360.0) * 360;
+}
+
+inline i16 angle_between(i16 target, i16 current) {
+    return angle(target - current + 180) - 180;
+}
+
 /// initialize some parts of cryxtels
 inline void init_start();
 
@@ -742,14 +750,14 @@ bool main_loop() {
         // FID (freno inerziale diamagnetico).
         // Non pi cos facile: ora c' lo SPIN.
         if (fid||lead||orig) {
-            v_alpha = alpha90 - alpha;
+            v_alpha = angle_between(alpha90, alpha);
             if (v_alpha>5) v_alpha = 5;
             if (v_alpha<-5) v_alpha = -5;
-            alpha += v_alpha;
-            v_beta = beta90 - beta;
+            alpha = angle(alpha + v_alpha);
+            v_beta = angle_between(beta90, beta);
             if (v_beta>5) v_beta = 5;
             if (v_beta<-5) v_beta = -5;
-            beta += v_beta;
+            beta = angle(beta + v_beta);
             if (alpha==alpha90 && beta==beta90) {
                 m = comera_m;
                 mx = beta * 5;
@@ -1776,6 +1784,13 @@ void extra_stop_extra ()
 
 void find_alphabeta()
 {
+    // Brute-force approach to find alpha and beta parameters
+    // from a desired orientation vector [ rx, ry, rz ],
+    // without using inverse trig function calls... but it's
+    // doing 3600 array accesses and 720 branch instructions,
+    // so is it really faster? Probably yes since the trig
+    // tables fit in L1 cache.
+    // The results are written into [ alpha90, beta90 ].
     kk = 1E9;
     for (c=0; c<360; c++) {
         x2 = cam_x - 100 * tsin[c] * tcos[alpha];
@@ -1799,6 +1814,11 @@ void find_alphabeta()
             kk = ox;
             alpha90 = c;
         }
+    }
+    // rectify the ship if it's "upside down"
+    if (alpha90 > 90 && alpha90 < 270) {
+        alpha90 = angle(180 - alpha90);
+        beta90 = angle(beta90 - 180);
     }
     play (FID, 1);
     subs = 0;

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1784,64 +1784,50 @@ void extra_stop_extra ()
 
 void find_alphabeta()
 {
-    // Brute-force approach to find alpha and beta parameters
-    // from a desired orientation vector [ rx, ry, rz ],
-    // without using inverse trig function calls... but it's
-    // doing 3600 array accesses and 720 branch instructions,
-    // so is it really faster? Probably yes since the trig
-    // tables fit in L1 cache.
-    // The results are written into [ alpha90, beta90 ].
-    kk = 1E9;
-    for (c=0; c<360; c++) {
-        x2 = cam_x - 100 * tsin[c] * tcos[alpha];
-        z2 = cam_z + 100 * tcos[c] * tcos[alpha];
-        y2 = cam_y + 100 * tsin[alpha];
-        ox = rx - x2; oy = ry - y2; oz = rz - z2;
-        ox = ox*ox+oy*oy+oz*oz;
-        if (ox<kk) {
-            kk = ox;
-            beta90 = c;
-        }
-    }
-    kk = 1E9;
-    for (c=0; c<360; c++) {
-        x2 = cam_x - 100 * tsin[beta90] * tcos[c];
-        z2 = cam_z + 100 * tcos[beta90] * tcos[c];
-        y2 = cam_y + 100 * tsin[c];
-        ox = rx - x2; oy = ry - y2; oz = rz - z2;
-        ox = ox*ox+oy*oy+oz*oz;
-        if (ox<kk) {
-            kk = ox;
-            alpha90 = c;
-        }
-    }
+    // find (alpha,beta) orientation of desired vector r
+    alpha90 = angle((i16) std::round((180.0 * std::asin(ry)) / Pi));
+    beta90 = angle((i16) std::round((180.0 * std::atan2(-rx, rz)) / Pi));
+
     // rectify the ship if it's "upside down"
     if (alpha90 > 90 && alpha90 < 270) {
         alpha90 = angle(180 - alpha90);
         beta90 = angle(beta90 - 180);
     }
+
     play (FID, 1);
     subs = 0;
     comera_m = m;
     m = 0;
 }
 
+// TODO: we should just have a vector library...
+// among other things, that would allow us to easily pass vectors to functions and return them
+void normalize_r ()
+{
+    float norm = 1.0 / std::sqrt(rx * rx + ry * ry + rz * rz);
+    rx *= norm;
+    ry *= norm;
+    rz *= norm;
+}
+
 void fid_on ()
 {
-        if (EVA_in_progress||trackframe||fid||lead||orig) return;
-        rx = cam_x + 100 * tsin[beta] * tcos[alpha];
-        rz = cam_z - 100 * tcos[beta] * tcos[alpha];
-        ry = cam_y - 100 * tsin[alpha];
-        find_alphabeta ();
-        fid = 1;
+    if (EVA_in_progress||trackframe||fid||lead||orig) return;
+    rx =   tsin[beta] * tcos[alpha];
+    rz = - tcos[beta] * tcos[alpha];
+    ry = - tsin[alpha];
+    // r is already a unit vector
+    find_alphabeta ();
+    fid = 1;
 }
 
 void lead_on ()
 {
     if (EVA_in_progress||trackframe||fid||lead||orig) return;
-    rx = cam_x + spd_x;
-    ry = cam_y + spd_y;
-    rz = cam_z + spd_z;
+    rx = spd_x;
+    ry = spd_y;
+    rz = spd_z;
+    normalize_r();
     find_alphabeta ();
     lead = 1;
 }
@@ -1849,9 +1835,10 @@ void lead_on ()
 void orig_on ()
 {
     if (EVA_in_progress||trackframe||fid||lead||orig) return;
-    rx = cam_x / 1.001;
-    ry = cam_y / 1.001;
-    rz = cam_z / 1.001;
+    rx = -cam_x;
+    ry = -cam_y;
+    rz = -cam_z;
+    normalize_r();
     find_alphabeta ();
     orig = 1;
 }


### PR DESCRIPTION
This PR changes the algorithm that determines how to point the ship's nose to a given direction.

The old algorithm would oftentimes choose a very roundabout way to rotate the ship, resulting in lower maneuverability, frustration and sometimes motion sickness.

The new algorithm is simpler, takes less time to rotate the ship, and includes a special check to correct the ship's roll in case the cockpit is upside down: after pressing either the LEAD, SPIN or ORIG key, the new orientation always has the cockpit oriented correctly. 

I think I've tested this thoroughly, but a sanity check is welcome either way.