### PR TITLE
Make it possible to build without SDL3_mixer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(SDL3 REQUIRED CONFIG REQUIRED COMPONENTS SDL3)
 
 ## SDL3_mixer
-find_package(SDL3_mixer REQUIRED)
+find_package(SDL3_mixer)
 
 # project includes
 include_directories(include)
@@ -21,6 +21,8 @@ include_directories(include)
 add_executable(cryxtels
     source/cryxtels.cpp source/fast3d.cpp source/global.cpp source/input.cpp
     source/text3d.cpp source/draw.cpp source/transition.cpp source/intro.cpp
-    source/conf.cpp source/dsp.cpp)
+    source/conf.cpp
+    $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>, source/dsp.cpp, source/dsp.stub.cpp>)
+
 target_link_libraries(cryxtels PRIVATE
-    SDL3::SDL3 $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer>)
+    SDL3::SDL3 $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,>)

--- a/source/cryxtels.cpp
+++ b/source/cryxtels.cpp
@@ -1305,7 +1305,6 @@ bool main_loop() {
 
 inline void init_start()
 {
-    int r;
     auto mem_ok = allocation_farm();
     if (!mem_ok) {
         cerr << "Not enough memory (seriously!?)" << endl;
@@ -1313,8 +1312,9 @@ inline void init_start()
     }
 
 	// Init SDL
-	r = SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
-	if (r < 0)
+    auto init_flags = audioEnabled ? SDL_INIT_VIDEO | SDL_INIT_AUDIO : SDL_INIT_VIDEO;
+    auto loaded = SDL_Init(init_flags); 
+	if (!loaded)
 	{	cerr << "Failed to init SDL: " << SDL_GetError() << endl;
 		throw 2;
     }

--- a/source/dsp.stub.cpp
+++ b/source/dsp.stub.cpp
@@ -1,0 +1,44 @@
+/** \file dsp.stub.cpp
+ *  This file is part of Crystal Pixels.
+ *
+ *  Crystal Pixels is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Crystal Pixels is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dsp.h"
+
+// implements public functions in header as no-ops
+
+/** Global variable for whether audio is enabled. */
+bool audioEnabled = false;
+
+void init_audio() {}
+
+void destroy_audio() {}
+
+bool set_sottofondo(const char*) {
+    return true;
+}
+
+void play(Audio, int, int) {}
+
+
+bool play_music(const char*, bool) {
+    return true;
+}
+
+const char* last_music_playing() {
+    return nullptr;
+}
+
+void audio_stop(int, int) {}


### PR DESCRIPTION
If SDL3_mixer cannot be found, disable audio entirely
